### PR TITLE
[Feat] 회원가입 테스트 및 작성자(멘토) 닉네임 정보 API 개발

### DIFF
--- a/src/main/java/com/developers/member/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/developers/member/common/entity/BaseTimeEntity.java
@@ -15,13 +15,13 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
     @CreatedDate
-    @Column(name="createdAt", updatable = false, nullable = false)
+    @Column(name="created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name="updatedAt")
+    @Column(name="updated_at")
     private LocalDateTime updatedAt;
 
-    @Column(name="deletedAt")
-    private LocalDateTime deletedAt;
+    @Column(name = "deleted")
+    private boolean deleted = false;
 }

--- a/src/main/java/com/developers/member/member/controller/AuthController.java
+++ b/src/main/java/com/developers/member/member/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.developers.member.member.controller;
+
+import com.developers.member.member.dto.request.MemberRegisterRequest;
+import com.developers.member.member.dto.response.MemberRegisterResponse;
+import com.developers.member.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<MemberRegisterResponse> register(@Valid @RequestBody MemberRegisterRequest request) {
+        MemberRegisterResponse response = memberService.register(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/developers/member/member/controller/MemberController.java
+++ b/src/main/java/com/developers/member/member/controller/MemberController.java
@@ -1,9 +1,7 @@
 package com.developers.member.member.controller;
 
-import com.developers.member.member.dto.request.MemberRegisterRequest;
-import com.developers.member.member.dto.response.MemberRegisterResponse;
+import com.developers.member.member.dto.response.MemberInfoResponse;
 import com.developers.member.member.service.MemberService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,13 +9,20 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/member")
+@RequestMapping("/api")
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping
-    public ResponseEntity<MemberRegisterResponse> register(@Valid @RequestBody MemberRegisterRequest request) {
-        MemberRegisterResponse response = memberService.register(request);
+    @GetMapping("/member")
+    public ResponseEntity<MemberInfoResponse> getWriterInfo(@RequestParam Long memberId) {
+        System.out.println(memberId);
+        MemberInfoResponse response = memberService.getWriterInfo(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/mentor")
+    public ResponseEntity<MemberInfoResponse> getMentorInfo(@RequestParam Long mentorId) {
+        MemberInfoResponse response = memberService.getMentorInfo(mentorId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/developers/member/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/MemberRegisterRequest.java
@@ -1,12 +1,14 @@
 package com.developers.member.member.dto.request;
 
-
 import com.developers.member.member.entity.Member;
 import com.developers.member.member.entity.Role;
 import com.developers.member.member.entity.Type;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
+/**
+ * 회원가입을 하기 위한 요청 DTO
+ */
 @Builder
 public class MemberRegisterRequest {
     @NotBlank(message = "이메일이 공백일 수 없습니다.")

--- a/src/main/java/com/developers/member/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,13 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 사용자(멘토) 닉네임 응답 DTO
+ */
+@Getter
+@Builder
+public class MemberInfoResponse {
+    private String memberName;
+}

--- a/src/main/java/com/developers/member/member/entity/Member.java
+++ b/src/main/java/com/developers/member/member/entity/Member.java
@@ -1,23 +1,27 @@
 package com.developers.member.member.entity;
 
 import com.developers.member.common.entity.BaseTimeEntity;
+import com.developers.member.point.entity.Point;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 /**
- * @DynamicInsert과 @DynamicUpdate 어노테이션 적용 여부 논의 필요
+ * 사용자 엔티티 클래스
+ * 사용자(Member)와 포인트(Point: 1대1 관계
+ * 사용자(Member)와 선택 칭호(MyBadge): 1대1 관계
+ * 사용자(Member)와 획득 칭호(MyBadge): 1대다 관계
+ * 사용자(Member)와 경력 정보(Career): 1대다 관계
  */
-
-//@DynamicUpdate
-//@DynamicInsert
 @NoArgsConstructor
 @Getter
 @ToString
+@SQLDelete(sql = "UPDATE member SET deleted = true WHERE member_id = ?")
+@Where(clause = "deleted = false")
 @Table(name = "member")
 @Entity
 public class Member extends BaseTimeEntity {
@@ -26,10 +30,10 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
 
     @Column(name = "password", nullable = false)
@@ -50,7 +54,7 @@ public class Member extends BaseTimeEntity {
     private String address;
 
     @Column(name = "is_mentor", nullable = false)
-    private boolean isMentor;
+    private boolean isMentor = false;
 
     @Column(name = "introduce")
     private String introduce;
@@ -60,6 +64,9 @@ public class Member extends BaseTimeEntity {
 
     @Column(name = "skills")
     private String skills;
+
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
+    private Point point;
 
     @Builder
     public Member(String email, String nickname, String password, Type type, Role role, String profileImageUrl, String address, boolean isMentor, String introduce, String position, String skills) {

--- a/src/main/java/com/developers/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/developers/member/member/repository/MemberRepository.java
@@ -3,5 +3,11 @@ package com.developers.member.member.repository;
 import com.developers.member.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
+/**
+ * findByIsMentorIsAndMemberId: 멘토로 등록된 사용자의 정보 조회
+ */
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByIsMentorIsAndMemberId(boolean isMentor, Long memberId);
 }

--- a/src/main/java/com/developers/member/member/service/MemberService.java
+++ b/src/main/java/com/developers/member/member/service/MemberService.java
@@ -2,7 +2,14 @@ package com.developers.member.member.service;
 
 import com.developers.member.member.dto.request.MemberRegisterRequest;
 import com.developers.member.member.dto.response.MemberRegisterResponse;
+import com.developers.member.member.dto.response.MemberInfoResponse;
 
 public interface MemberService {
     MemberRegisterResponse register(MemberRegisterRequest request);
+
+    MemberInfoResponse getWriterInfo(Long memberId);
+
+    MemberInfoResponse getMentorInfo(Long mentorId);
+
+
 }

--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.developers.member.member.service;
 import com.developers.member.member.dto.request.MemberRegisterRequest;
 import com.developers.member.member.dto.response.MemberIdResponse;
 import com.developers.member.member.dto.response.MemberRegisterResponse;
+import com.developers.member.member.dto.response.MemberInfoResponse;
 import com.developers.member.member.entity.Member;
 import com.developers.member.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +11,13 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 /**
  *
  * register: 회원가입
+ * getWriterInfo: 사용자의 닉네임 정보를 전달하는 Open API
+ * getMentorInfo: 멘토인 사용자의 닉네임 정보를 전달하는 Open API
  */
 @Log4j2
 @RequiredArgsConstructor
@@ -29,6 +34,24 @@ public class MemberServiceImpl implements MemberService {
                 .code(HttpStatus.OK.name())
                 .msg("회원가입이 정상적으로 처리되었습니다.")
                 .data(memberIdResponse)
+                .build();
+    }
+
+    @Override
+    public MemberInfoResponse getWriterInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException(memberId + " 번호는 존재하지 않는 회원입니다."));
+        return MemberInfoResponse.builder()
+                .memberName(member.getNickname())
+                .build();
+    }
+
+    @Override
+    public MemberInfoResponse getMentorInfo(Long mentorId) {
+        Member member = memberRepository.findByIsMentorIsAndMemberId(true, mentorId)
+                .orElseThrow(() -> new NoSuchElementException(mentorId + " 번호는 멘토로 등록되지 않은 회원입니다."));
+        return MemberInfoResponse.builder()
+                .memberName(member.getNickname())
                 .build();
     }
 }

--- a/src/test/java/com/developers/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/developers/member/repository/MemberRepositoryTest.java
@@ -1,19 +1,45 @@
 package com.developers.member.repository;
 
+import com.developers.member.config.JpaConfig;
 import com.developers.member.member.entity.Member;
 import com.developers.member.member.entity.Role;
 import com.developers.member.member.entity.Type;
 import com.developers.member.member.repository.MemberRepository;
+import jakarta.persistence.EntityListeners;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
-@SpringBootTest
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * @DataJpaTest: JPA 테스트를 위한 어노테이션으로 JPA 관련 설정만 로드하여 테스트를 수행
+ * @AutoConfigureTestDatabase: 테스트용 데이터베이스를 자동으로 구성해주는 어노테이션으로 replace 속성을 NONE으로 설정하여 실제 데이터베이스를 사용하여 테스트를 수행
+ * @ActiveProfiles("local"): 테스트에 application-local.yml 설정파일을 사용하도록 설정
+ * @Import(JpaConfig.class): 테스트 시 JpaConfig 클래스를 사용하도록 설정
+ *
+ */
+
+//@SpringBootTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("local")
 public class MemberRepositoryTest {
     @Autowired private MemberRepository memberRepository;
+
+    @DisplayName("한명의 회원 데이터 저장")
     @Test
     public void save() {
         // given
@@ -23,7 +49,8 @@ public class MemberRepositoryTest {
                 .nickname("lango")
                 .type(Type.LOCAL)
                 .role(Role.USER)
-                .isMentor(false)
+                .profileImageUrl("/root/1")
+                .isMentor(true)
                 .address("서울특별시 강남구")
                 .introduce("안녕하세요 저는 ...")
                 .build();
@@ -37,5 +64,105 @@ public class MemberRepositoryTest {
         Assertions.assertEquals("lango@kakao.com", result.getEmail());
         Assertions.assertEquals("안녕하세요 저는 ...", result.getIntroduce());
         Assertions.assertEquals("lango", result.getNickname());
+    }
+
+    @DisplayName("50명의 회원 데이터 저장")
+    @Test
+    public void bulkSave() {
+        // given
+        IntStream.rangeClosed(1, 50).forEach(i -> {
+            Member member = Member.builder()
+                    .email("test+"+i+"+@kakao.com")
+                    .password("kakao123")
+                    .nickname("kakao@"+i)
+                    .type(Type.LOCAL)
+                    .role(Role.USER)
+                    .isMentor(false)
+                    .profileImageUrl("/root/"+i)
+                    .build();
+            memberRepository.save(member);
+        });
+        // when
+        List<Member> allMembers = memberRepository.findAll();
+        for (Member member: allMembers) {
+            System.out.println(">>> member saved #" + member.getMemberId() + " member:" + member.toString());
+        }
+        // then
+        for (Member member: allMembers) {
+            assertThat(member.getMemberId()).isNotNull();
+        }
+    }
+
+
+    @DisplayName("두 명의 회원 조회")
+    @Test
+    public void findById() {
+        // given
+        Member member1 = Member.builder()
+                .email("test1@kakao.com")
+                .password("kakao123")
+                .nickname("kakao@1")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(false)
+                .profileImageUrl("/root/1")
+                .build();
+        Member member2 = Member.builder()
+                .email("test2@kakao.com")
+                .password("kakao123")
+                .nickname("kakao@2")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(false)
+                .profileImageUrl("/root/2")
+                .build();
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        // when
+        Member findMember1 = memberRepository.findById(member1.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("Wrong MemberId:<" + member1.getMemberId() + ">"));
+        Member findMember2 = memberRepository.findById(member2.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("Wrong MemberId:<" + member2.getMemberId() + ">"));
+        // then
+        assertThat(memberRepository.count()).isEqualTo(2);
+        assertThat(findMember1.getNickname()).isEqualTo("kakao@1");
+        assertThat(findMember1.getProfileImageUrl()).isEqualTo("/root/1");
+        assertThat(findMember2.getNickname()).isEqualTo("kakao@2");
+        assertThat(findMember2.getProfileImageUrl()).isEqualTo("/root/2");
+    }
+
+    @DisplayName("멘토 회원 조회")
+    @Test
+    public void memberIsMentor() {
+        // given
+        Member member = Member.builder()
+                .email("menber111@kakao.com")
+                .password("kakao123")
+                .nickname("member@1")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(false)
+                .profileImageUrl("/root/1")
+                .build();
+        Member mentor = Member.builder()
+                .email("mentor@kakao.com")
+                .password("kakao123")
+                .nickname("mentor@1")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(true)
+                .profileImageUrl("/root/2")
+                .build();
+        memberRepository.save(member);
+        memberRepository.save(mentor);
+        // when
+        Member member1 = memberRepository.findById(member.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("Wrong MemberId:<" + member.getMemberId() + ">"));
+        Member mentor1 = memberRepository.findByIsMentorIsAndMemberId(mentor.isMentor(), mentor.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("Wrong MemberId:<" + mentor.getMemberId() + ">"));
+        // then
+        assertThat(memberRepository.count()).isEqualTo(2);
+        assertThat(member1.isMentor()).isFalse();
+        assertThat(mentor1.isMentor()).isTrue();
     }
 }

--- a/src/test/java/com/developers/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/service/MemberServiceTest.java
@@ -1,30 +1,109 @@
 package com.developers.member.service;
 
+import com.developers.member.member.dto.request.MemberRegisterRequest;
+import com.developers.member.member.dto.response.MemberIdResponse;
+import com.developers.member.member.dto.response.MemberInfoResponse;
+import com.developers.member.member.dto.response.MemberRegisterResponse;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.entity.Role;
+import com.developers.member.member.entity.Type;
 import com.developers.member.member.repository.MemberRepository;
-import com.developers.member.member.service.MemberService;
+import com.developers.member.member.service.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
-import static org.mockito.BDDMockito.given;
+import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * @ExtendWith(MockitoExtension.class): Mockito를 사용한 테스트를 위한 어노테이션으로 Mockito 관련 기능을 사용하도록 설정
+ * @Mock: 모키토(Mockito)를 사용하여 Mock 객체를 생성하는 어노테이션으로 MemberRepository 인터페이스를 구현한 Mock 객체를 생성
+ * @InjectMocks: MemberServiceImpl 클래스에 @Mock으로 생성된 MemberRepository Mock 객체를 주입
+ *
+ */
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
     @InjectMocks
-    private MemberService memberService;
+    private MemberServiceImpl memberService;
 
+    @DisplayName("사용자 회원가입")
     @Test
-    void 사용자_회원가입() {
+    public void register() {
         // given
-//            given(memberRepository.findById(1L)).willReturn()
+        MemberRegisterRequest request = MemberRegisterRequest.builder()
+                .email("test1@kakao.com")
+                .nickName("test1")
+                .password("kakao123")
+                .profileImageUrl("/root/1")
+                .build();
+        Member member = request.toEntity();
+        when(memberRepository.save(any())).thenReturn(member);
+
         // when
+        MemberRegisterResponse response = memberService.register(request);
 
         // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.name());
+        assertThat(response.getMsg()).isEqualTo("회원가입이 정상적으로 처리되었습니다.");
+        assertThat(response.getData()).isInstanceOf(MemberIdResponse.class);
+        assertThat(response.getData().getMemberId()).isEqualTo(member.getMemberId());
     }
 
+    @DisplayName("작성자 닉네임 정보 조회")
+    @Test
+    void getWriterInfo() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+                .email("lango@kakao.com")
+                .password("kakao123")
+                .nickname("lango")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+
+        // when
+        MemberInfoResponse response = memberService.getWriterInfo(memberId);
+
+        // then
+        assertThat(response.getMemberName()).isEqualTo("lango");
+    }
+
+    @DisplayName("멘토 닉네임 정보 조회")
+    @Test
+    void getMentorInfo() {
+        // given
+        Long memberId = 2L;
+        Member member = Member.builder()
+                .email("mentor@kakao.com")
+                .password("kakao123")
+                .nickname("mentor")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(true)
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+
+        // when
+        MemberInfoResponse response = memberService.getWriterInfo(memberId);
+
+        // then
+        assertThat(response.getMemberName()).isEqualTo("mentor");
+    }
 }
+


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 회원가입 기능 테스트 코드 작성
- 작성자(멘토) 정보 조회 API 개발

<br>

## 💡 Key Changes
- 회원가입 기능 관련 repository와 service 계층의 단위 테스트 코드를 작성하였습니다.
    - Repository 테스트의 경우 `@DataJpaTest` 어노테이션을 활용하여 단위테스트를 진행하였습니다.
    - Service 테스트의 경우는 `@ExtendWith(MockitoExtension.class)` 어노테이션을 한 Mockito를 이용해 단위 테스트를 진행하였습니다.

-  모든 엔티티 클래스의 `@Column` 어노테이션의 name 속성을 실제 DB 테이블의 생성되는 컬럼명과 일치시키도록 수정하였습니다.
    - `@Colum(name="member_id")` 형식과 같이 수정하였습니다. `(name="memberId")`와 같이 작성한다면 DB 컬럼명과 혼동이 생겨 가독성이 떨어질 것이라 판단했기 때문입니다.

- 공동으로 사용할 컬럼들인 BaseTimeEntity에서 삭제시간을 담을 deleted_at 컬럼에 삭제시간을 담지 않고 삭제 여부만 담을 수 있도록 수정하였습니다. 
    - 삭제시간을 삽입할 때마다 불필요한 연산을 수행해야 하기 때문에 현재 서비스의 규모에서는 삭제여부 정도만 Soft Delete 방식으로 처리해도 무방할 것이라 생각됩니다.


- 문제풀이 서비스에서 사용할 **_사용자(작성자) 닉네임 정보 조회 API_** 포맷입니다.
![image](https://user-images.githubusercontent.com/59594946/228013394-e0fe7e50-7717-4d49-84c8-6d73b66223bc.png)

- 화상 채팅 서비스에서 사용할 **_멘토 닉네임 정보 조회 API_** 포맷입니다.
![image](https://user-images.githubusercontent.com/59594946/228013028-743fd456-a414-4190-9356-5f59a49cb5e9.png)

> 추후 위 2가지의 API를 각자의 서비스에서 RestTemplate으로 통신하여 조회하여 사용하면 됩니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @soojik @paduck-96 @ITfervor @EagerProgrammer 
---
close #10
close #12
