### PR TITLE
[Feat] 사용자 개인정보 관련 API 개발 완료

### DIFF
--- a/src/main/java/com/developers/member/config/securityConfig.java
+++ b/src/main/java/com/developers/member/config/securityConfig.java
@@ -1,0 +1,36 @@
+//package com.developers.member.config;
+//
+//import com.developers.member.member.entity.Role;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//import org.springframework.security.crypto.password.PasswordEncoder;
+//import org.springframework.security.web.SecurityFilterChain;
+//
+//@EnableWebSecurity
+//public class securityConfig {
+//    @Bean
+//    PasswordEncoder passwordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        http
+//                .csrf().disable()
+//                .authorizeHttpRequests()
+//                .requestMatchers("/api/authenticate", "/ouath2/**", "/api/login", "/api/register", "/api/profile/**").permitAll()
+//                .requestMatchers("/api/v1/**").hasRole(Role.USER.name())
+//                .anyRequest().authenticated()
+//
+//                .and()
+//                .logout()
+//                .logoutSuccessUrl("/");
+////                .and()
+////                .oauth2Login()
+////                .userInfoEndpoint()
+////                .userService(customOAuth2UserService);
+//        return http.build();
+//    }
+//
+//}

--- a/src/main/java/com/developers/member/member/controller/AuthController.java
+++ b/src/main/java/com/developers/member/member/controller/AuthController.java
@@ -20,6 +20,11 @@ public class AuthController {
 
     private final MemberService memberService;
 
+    /**
+     * 사용자 회원가입
+     * @param request 이메일, 비밀번호, 닉네임, 프로필이미지경로, 주소, 직무, 기술스택
+     * @return MemberRegisterResponse
+     */
     @PostMapping
     public ResponseEntity<MemberRegisterResponse> register(@Valid @RequestBody MemberRegisterRequest request) {
         MemberRegisterResponse response = memberService.register(request);

--- a/src/main/java/com/developers/member/member/controller/MemberController.java
+++ b/src/main/java/com/developers/member/member/controller/MemberController.java
@@ -13,13 +13,22 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
+    /**
+     * 사용자 닉네임 정보 전달
+     * @param memberId 사용자 PK 번호
+     * @return MemberInfoResponse
+     */
     @GetMapping("/member")
     public ResponseEntity<MemberInfoResponse> getWriterInfo(@RequestParam Long memberId) {
-        System.out.println(memberId);
         MemberInfoResponse response = memberService.getWriterInfo(memberId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    /**
+     * 멘토 사용자 닉네임 정보 전달 - 멘토 등록된 사용자의 정보를 전달
+     * @param mentorId 사용자 PK 번호
+     * @return MemberInfoResponse
+     */
     @GetMapping("/mentor")
     public ResponseEntity<MemberInfoResponse> getMentorInfo(@RequestParam Long mentorId) {
         MemberInfoResponse response = memberService.getMentorInfo(mentorId);

--- a/src/main/java/com/developers/member/member/controller/ProfileController.java
+++ b/src/main/java/com/developers/member/member/controller/ProfileController.java
@@ -1,0 +1,68 @@
+package com.developers.member.member.controller;
+
+import com.developers.member.member.dto.request.NicknameUpdateRequest;
+import com.developers.member.member.dto.request.PasswordChangeRequest;
+import com.developers.member.member.dto.request.ProfileImageUpdateRequest;
+import com.developers.member.member.dto.response.NicknameUpdateResponse;
+import com.developers.member.member.dto.response.PasswordChangeResponse;
+import com.developers.member.member.dto.response.ProfileGetResponse;
+import com.developers.member.member.dto.response.ProfileImageUpdateResponse;
+import com.developers.member.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class ProfileController {
+    private final MemberService memberService;
+
+    /**
+     * 개인정보 조회
+     * @param memberId 사용자 PK 번호
+     * @return ProfileGetResponse
+     */
+    @GetMapping("/profile/{memberId}")
+    public ResponseEntity<ProfileGetResponse> getProfile(@Valid @PathVariable Long memberId) {
+        ProfileGetResponse response = memberService.getProfile(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 닉네임 변경
+     * @param request 사용자의 PK 번호, 변경할 닉네임 정보
+     * @return NicknameUpdateResponse
+     */
+    @PatchMapping("/nickname")
+    public ResponseEntity<NicknameUpdateResponse> updateNickname(@Valid @RequestBody NicknameUpdateRequest request) {
+        NicknameUpdateResponse response = memberService.updateNickname(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 프로필 이미지 변경
+     * @param request 사용자의 PK 번호, 변경할 이미지 경로
+     * @return ProfileImageUpdateResponse
+     */
+
+    @PatchMapping("/profileimg")
+    public ResponseEntity<ProfileImageUpdateResponse> updateProfileImg(@Valid @RequestBody ProfileImageUpdateRequest request) {
+        ProfileImageUpdateResponse response = memberService.updateProfileImg(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 비밀번호 변경
+     * @param request 사용자의 PK 번호, 변경할 비밀번호
+     * @return PasswordChangeResponse
+     */
+
+    @PatchMapping("/password")
+    public ResponseEntity<PasswordChangeResponse> changePassword(@Valid @RequestBody PasswordChangeRequest request) {
+        PasswordChangeResponse response = memberService.changePassword(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/developers/member/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/MemberRegisterRequest.java
@@ -5,18 +5,20 @@ import com.developers.member.member.entity.Role;
 import com.developers.member.member.entity.Type;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
+import lombok.Getter;
 
 /**
  * 회원가입을 하기 위한 요청 DTO
  */
 @Builder
+@Getter
 public class MemberRegisterRequest {
     @NotBlank(message = "이메일이 공백일 수 없습니다.")
     private String email;
     @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
     private String password;
     @NotBlank(message = "사용자의 닉네임은 공백일 수 없습니다.")
-    private String nickName;
+    private String nickname;
     @NotBlank(message = "사용자의 프로필 이미지는 공백일 수 없습니다.")
     private String profileImageUrl;
     private String address;
@@ -27,13 +29,14 @@ public class MemberRegisterRequest {
         return Member.builder()
                 .email(email)
                 .password(password)
-                .nickname(nickName)
+                .nickname(nickname)
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .profileImageUrl(profileImageUrl)
                 .address(address)
                 .position(position)
                 .skills(skills)
+                .point(100L)
                 .build();
     }
 

--- a/src/main/java/com/developers/member/member/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.developers.member.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 닉네임을 변경하기 위한 요청 DTO
+ */
+@Getter
+@Builder
+public class NicknameUpdateRequest {
+    private Long memberId;
+    private String nickname;
+}

--- a/src/main/java/com/developers/member/member/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,11 @@
+package com.developers.member.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordChangeRequest {
+    private Long memberId;
+    private String password;
+}

--- a/src/main/java/com/developers/member/member/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.developers.member.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImageUpdateRequest {
+    private Long memberId;
+    private String imagePath;
+}

--- a/src/main/java/com/developers/member/member/dto/response/MemberIdWithNicknameResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberIdWithNicknameResponse.java
@@ -1,0 +1,20 @@
+package com.developers.member.member.dto.response;
+
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 작성자 PK 번호 및 닉네임 정보 응답 DTO
+ */
+@Getter
+public class MemberIdWithNicknameResponse {
+    private Long memberId;
+    private String nickname;
+
+    @Builder
+    public MemberIdWithNicknameResponse(Long memberId, String nickname) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/developers/member/member/dto/response/MemberIdWithPointResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberIdWithPointResponse.java
@@ -1,0 +1,16 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * 작성자 PK 정보 및 점수 응답 DTO
+ */
+@Builder
+@ToString
+@Getter
+public class MemberIdWithPointResponse {
+    private Long memberId;
+    private Long point;
+}

--- a/src/main/java/com/developers/member/member/dto/response/MemberRegisterResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberRegisterResponse.java
@@ -3,19 +3,21 @@ package com.developers.member.member.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * 회원가입 API 응답 DTO
  */
 @NoArgsConstructor
+@ToString
 @Getter
 public class MemberRegisterResponse {
     private String code;
     private String msg;
-    private MemberIdResponse data;
+    private MemberIdWithPointResponse data;
 
     @Builder
-    public MemberRegisterResponse(String code, String msg, MemberIdResponse data) {
+    public MemberRegisterResponse(String code, String msg, MemberIdWithPointResponse data) {
         this.code = code;
         this.msg = msg;
         this.data = data;

--- a/src/main/java/com/developers/member/member/dto/response/NicknameUpdateResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/NicknameUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 개인정보 닉네임 변경 응답 DTO
+ */
+@Builder
+@Getter
+public class NicknameUpdateResponse {
+    private String code;
+    private String msg;
+    private MemberIdWithNicknameResponse data;
+}

--- a/src/main/java/com/developers/member/member/dto/response/PasswordChangeResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,12 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordChangeResponse {
+    private String code;
+    private String msg;
+    private MemberIdResponse data;
+}

--- a/src/main/java/com/developers/member/member/dto/response/ProfileGetResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/ProfileGetResponse.java
@@ -1,0 +1,16 @@
+package com.developers.member.member.dto.response;
+
+import com.developers.member.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 개인정보 조회 응답 DTO
+ */
+@Builder
+@Getter
+public class ProfileGetResponse {
+    private String code;
+    private String msg;
+    private ProfileResponse data;
+}

--- a/src/main/java/com/developers/member/member/dto/response/ProfileImageUpdateResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/ProfileImageUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImageUpdateResponse {
+    private String code;
+    private String msg;
+    private ProfileImgPathResponse data;
+}

--- a/src/main/java/com/developers/member/member/dto/response/ProfileImgPathResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/ProfileImgPathResponse.java
@@ -1,0 +1,10 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImgPathResponse {
+    private String path;
+}

--- a/src/main/java/com/developers/member/member/dto/response/ProfileResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/ProfileResponse.java
@@ -1,0 +1,22 @@
+package com.developers.member.member.dto.response;
+
+import com.developers.member.point.entity.Point;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 마이페이지에서 개인정보 조회시 전달할 Member 데이터를 가지는 응답 DTO
+ */
+@Builder
+@Getter
+public class ProfileResponse {
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    private boolean isMentor;
+    private String address;
+    private String introduce;
+    private String position;
+    private String skills;
+    private Long point;
+}

--- a/src/main/java/com/developers/member/member/entity/Member.java
+++ b/src/main/java/com/developers/member/member/entity/Member.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.Where;
  */
 @NoArgsConstructor
 @Getter
-@ToString
+@ToString(exclude = {"point"})
 @SQLDelete(sql = "UPDATE member SET deleted = true WHERE member_id = ?")
 @Where(clause = "deleted = false")
 @Table(name = "member")
@@ -65,11 +65,11 @@ public class Member extends BaseTimeEntity {
     @Column(name = "skills")
     private String skills;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Point point;
 
     @Builder
-    public Member(String email, String nickname, String password, Type type, Role role, String profileImageUrl, String address, boolean isMentor, String introduce, String position, String skills) {
+    public Member(String email, String nickname, String password, Type type, Role role, String profileImageUrl, String address, boolean isMentor, String introduce, String position, String skills, Long point) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
@@ -81,6 +81,7 @@ public class Member extends BaseTimeEntity {
         this.introduce = introduce;
         this.position = position;
         this.skills = skills;
+        this.point = Point.builder().member(this).point(point).build();
     }
     public void updateNickname(String nickname) {
         if (nickname != null) {
@@ -103,4 +104,18 @@ public class Member extends BaseTimeEntity {
     public void updateIntroduce(String introduce) {
         this.introduce = introduce;
     }
+
+    public void increasePoint(Long point) {
+        this.point = Point.builder()
+                .point(this.point.getPoint() + point)
+                .build();
+    }
+
+    public void decreasePoint(Long point) {
+        this.point = Point.builder()
+                .point(this.point.getPoint() - point)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/developers/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/developers/member/member/repository/MemberRepository.java
@@ -10,4 +10,8 @@ import java.util.Optional;
  */
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIsMentorIsAndMemberId(boolean isMentor, Long memberId);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/developers/member/member/service/MemberService.java
+++ b/src/main/java/com/developers/member/member/service/MemberService.java
@@ -1,8 +1,10 @@
 package com.developers.member.member.service;
 
 import com.developers.member.member.dto.request.MemberRegisterRequest;
-import com.developers.member.member.dto.response.MemberRegisterResponse;
-import com.developers.member.member.dto.response.MemberInfoResponse;
+import com.developers.member.member.dto.request.NicknameUpdateRequest;
+import com.developers.member.member.dto.request.PasswordChangeRequest;
+import com.developers.member.member.dto.request.ProfileImageUpdateRequest;
+import com.developers.member.member.dto.response.*;
 
 public interface MemberService {
     MemberRegisterResponse register(MemberRegisterRequest request);
@@ -12,4 +14,11 @@ public interface MemberService {
     MemberInfoResponse getMentorInfo(Long mentorId);
 
 
+    ProfileGetResponse getProfile(Long memberId);
+
+    NicknameUpdateResponse updateNickname(NicknameUpdateRequest request);
+
+    ProfileImageUpdateResponse updateProfileImg(ProfileImageUpdateRequest request);
+
+    PasswordChangeResponse changePassword(PasswordChangeRequest request);
 }

--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -1,17 +1,20 @@
 package com.developers.member.member.service;
 
 import com.developers.member.member.dto.request.MemberRegisterRequest;
-import com.developers.member.member.dto.response.MemberIdResponse;
-import com.developers.member.member.dto.response.MemberRegisterResponse;
-import com.developers.member.member.dto.response.MemberInfoResponse;
+import com.developers.member.member.dto.request.NicknameUpdateRequest;
+import com.developers.member.member.dto.request.PasswordChangeRequest;
+import com.developers.member.member.dto.request.ProfileImageUpdateRequest;
+import com.developers.member.member.dto.response.*;
 import com.developers.member.member.entity.Member;
 import com.developers.member.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  *
@@ -27,20 +30,31 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public MemberRegisterResponse register(MemberRegisterRequest request) {
-        Member member = request.toEntity();
-        Long saveMemberId = memberRepository.save(member).getMemberId();
-        MemberIdResponse memberIdResponse = MemberIdResponse.builder().memberId(saveMemberId).build();
-        return MemberRegisterResponse.builder()
-                .code(HttpStatus.OK.name())
-                .msg("회원가입이 정상적으로 처리되었습니다.")
-                .data(memberIdResponse)
-                .build();
+        try {
+            Member member = request.toEntity();
+            Long saveMemberId = memberRepository.save(member).getMemberId();
+            MemberIdWithPointResponse response = MemberIdWithPointResponse.builder()
+                    .memberId(saveMemberId)
+                    .point(member.getPoint().getPoint())
+                    .build();
+            return MemberRegisterResponse.builder()
+                    .code(HttpStatus.OK.toString())
+                    .msg("회원가입이 정상적으로 처리되었습니다.")
+                    .data(response)
+                    .build();
+        } catch (Exception e) {
+            return MemberRegisterResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("회원가입 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
     }
 
     @Override
     public MemberInfoResponse getWriterInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException(memberId + " 번호는 존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new NoSuchElementException(memberId + " 번호는 존재하지 않는 회원입니다."));
         return MemberInfoResponse.builder()
                 .memberName(member.getNickname())
                 .build();
@@ -53,5 +67,147 @@ public class MemberServiceImpl implements MemberService {
         return MemberInfoResponse.builder()
                 .memberName(member.getNickname())
                 .build();
+    }
+
+    @Override
+    public ProfileGetResponse getProfile(Long memberId) {
+        try {
+            Optional<Member> member = memberRepository.findById(memberId);
+            if(member.isPresent()) {
+                Long point = member.get().getPoint().getPoint();
+                ProfileResponse profile = ProfileResponse.builder()
+                        .email(member.get().getEmail())
+                        .nickname(member.get().getNickname())
+                        .profileImageUrl(member.get().getProfileImageUrl())
+                        .isMentor(member.get().isMentor())
+                        .address(member.get().getAddress())
+                        .introduce(member.get().getIntroduce())
+                        .position(member.get().getPosition())
+                        .skills(member.get().getSkills())
+                        .point(point)
+                        .build();
+                return ProfileGetResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 나의 정보를 조회하였습니다.")
+                        .data(profile)
+                        .build();
+            } else {
+                return ProfileGetResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return ProfileGetResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("나의 정보를 조회하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public NicknameUpdateResponse updateNickname(NicknameUpdateRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if(member.isPresent()) {
+                boolean duplicate = memberRepository.existsByNickname(request.getNickname());
+                System.out.println(duplicate);
+                if(duplicate == true) {
+                    return NicknameUpdateResponse.builder()
+                            .code(HttpStatus.CONFLICT.toString())
+                            .msg("이미 사용중인 닉네임입니다.")
+                            .data(null)
+                            .build();
+                }
+                member.get().updateNickname(request.getNickname());
+                MemberIdWithNicknameResponse memberIdWithNickname = MemberIdWithNicknameResponse.builder()
+                        .memberId(member.get().getMemberId())
+                        .nickname(member.get().getNickname())
+                        .build();
+                return NicknameUpdateResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 닉네임을 변경하였습니다.")
+                        .data(memberIdWithNickname)
+                        .build();
+            } else {
+                return NicknameUpdateResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return NicknameUpdateResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("닉네임 변경 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public ProfileImageUpdateResponse updateProfileImg(ProfileImageUpdateRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if(member.isPresent()) {
+                String imagePath = request.getImagePath();
+                member.get().updateProfileImageUrl(imagePath);
+                ProfileImgPathResponse res = ProfileImgPathResponse.builder()
+                        .path(imagePath)
+                        .build();
+                return ProfileImageUpdateResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 프로필 이미지를 변경하였습니다.")
+                        .data(res)
+                        .build();
+            } else {
+                return ProfileImageUpdateResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return ProfileImageUpdateResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("프로필 이미지를 변경하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public PasswordChangeResponse changePassword(PasswordChangeRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if(member.isPresent()) {
+                member.get().changePassword(request.getPassword());
+                MemberIdResponse memberId = MemberIdResponse.builder()
+                        .memberId(member.get().getMemberId())
+                        .build();
+                return PasswordChangeResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 비밀번호가 변경되었습니다.")
+                        .data(memberId)
+                        .build();
+            } else {
+                return PasswordChangeResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return PasswordChangeResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("비밀번호를 변경하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/developers/member/point/entity/Point.java
+++ b/src/main/java/com/developers/member/point/entity/Point.java
@@ -3,6 +3,7 @@ package com.developers.member.point.entity;
 import com.developers.member.common.entity.BaseTimeEntity;
 import com.developers.member.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.Where;
 
 @NoArgsConstructor
 @Getter
-@ToString
+@ToString(exclude = {"member"})
 @SQLDelete(sql = "UPDATE point SET deleted = true WHERE point_id = ?")
 @Where(clause = "deleted = false")
 @Table(name = "point")
@@ -24,8 +25,16 @@ public class Point extends BaseTimeEntity {
     private Long pointId;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "point")
+    @Column(name = "point", nullable = false)
     private Long point;
+
+    @Builder
+    public Point(Member member, Long point) {
+        this.member = member;
+        this.point = point;
+
+    }
 }

--- a/src/main/java/com/developers/member/point/repository/PointRepository.java
+++ b/src/main/java/com/developers/member/point/repository/PointRepository.java
@@ -1,0 +1,9 @@
+package com.developers.member.point.repository;
+
+import com.developers.member.member.entity.Member;
+import com.developers.member.point.entity.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+    Point findByMember(Member member);
+}


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 개인정보 관련 API 개발 완료

<br>

## 💡 Key Changes
- 개인정보 조회, 비밀번호 변경, 닉네임 변경, 프로필 이미지 변경 API가 개발 완료되었습니다.
- 사용자 엔티티인 Member와 사용자 점수를 관리할 Point 엔티티를 추가하였습니다.
    - Member와 Point는 1**대1 관계**로 설정되어 있습니다.
    - 사용자 데이터가 생성될 때 사용자의 점수도 기본적으로 추가되어야 하기에 **회원가입이 되는 순간 사용자의 점수도 기본으로 100점으로 삽입**될 수 있도록 Point 엔티티를 `CaseCade` 옵션을 부여하였으며, 사용자가 회원 탈퇴시 해당 회원의 점수도 무의미하기에 함께 삭제될 수 있도록 `orphanRemoval` 설정을 추가하였습니다.
- 모든 비즈니스 로직의 예외를 기본적으로는 try/catch 구문으로 묶어서 성공할 경우의 응답과 예외 발생시의 응답을 구분하였습니다.
    - 예시(닉네임 변경 성공 및 실패)

```json
{
    "code": "200 OK",
    "msg": "정상적으로 닉네임을 변경하였습니다.",
    "data": {
        "memberId": 187,
        "nickname": "111"
    }
}
```

```json
{
    "code": "404 NOT_FOUND",
    "msg": "존재하지 않는 사용자입니다.",
    "data": null
}
```

- Repositorty와 Service Test의 경우 메서드별로 작성하였습니다.
    - Repository의 경우 사용자 데이터의 CRUD 작업 위주로 테스트를 진행하였습니다.
    - Service의 경우 서비스로 구현한 각 기능들, 즉 회원가입, 비밀번호 변경, 닉네임 변경 등 실제 기능을 구현한 메서드를 테스트할 수 있도록 작성하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 

---

close #3