### PR TITLE
[Feat] 사용자 점수 적립 및 차감 API 개발 완료

### DIFF
--- a/src/main/java/com/developers/member/member/controller/ProfileController.java
+++ b/src/main/java/com/developers/member/member/controller/ProfileController.java
@@ -26,7 +26,7 @@ public class ProfileController {
      * @return ProfileGetResponse
      */
     @GetMapping("/profile/{memberId}")
-    public ResponseEntity<ProfileGetResponse> getProfile(@Valid @PathVariable Long memberId) {
+    public ResponseEntity<ProfileGetResponse> getProfile(@PathVariable Long memberId) {
         ProfileGetResponse response = memberService.getProfile(memberId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/developers/member/member/entity/Member.java
+++ b/src/main/java/com/developers/member/member/entity/Member.java
@@ -104,17 +104,12 @@ public class Member extends BaseTimeEntity {
     public void updateIntroduce(String introduce) {
         this.introduce = introduce;
     }
-
     public void increasePoint(Long point) {
-        this.point = Point.builder()
-                .point(this.point.getPoint() + point)
-                .build();
+        this.point.increase(point);
     }
 
     public void decreasePoint(Long point) {
-        this.point = Point.builder()
-                .point(this.point.getPoint() - point)
-                .build();
+        this.point.decrease(point);
     }
 
 

--- a/src/main/java/com/developers/member/point/controller/PointController.java
+++ b/src/main/java/com/developers/member/point/controller/PointController.java
@@ -1,0 +1,44 @@
+package com.developers.member.point.controller;
+
+import com.developers.member.point.dto.request.MemberPointRequest;
+import com.developers.member.point.dto.response.MemberPointResponse;
+import com.developers.member.point.service.PointService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/point")
+public class PointController {
+    private final PointService pointService;
+
+    /**
+     * 점수 적립
+     * @param request 사용자의 PK 번호
+     * @return MemberPointResponse
+     */
+    @PatchMapping("/increase")
+    public ResponseEntity<MemberPointResponse> increasePoint(@Valid @RequestBody MemberPointRequest request) {
+        MemberPointResponse response = pointService.increasePoint(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 점수 차감
+     * @param request 사용자의 PK 번호
+     * @return MemberPointResponse
+     */
+    @PatchMapping("/decrease")
+    public ResponseEntity<MemberPointResponse> decreasePoint(@Valid @RequestBody MemberPointRequest request) {
+        MemberPointResponse response = pointService.decreasePoint(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/developers/member/point/dto/request/MemberPointRequest.java
+++ b/src/main/java/com/developers/member/point/dto/request/MemberPointRequest.java
@@ -1,0 +1,16 @@
+package com.developers.member.point.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class MemberPointRequest {
+    @NotNull
+    private Long memberId;
+}

--- a/src/main/java/com/developers/member/point/dto/response/MemberPointResponse.java
+++ b/src/main/java/com/developers/member/point/dto/response/MemberPointResponse.java
@@ -1,0 +1,14 @@
+package com.developers.member.point.dto.response;
+
+import com.developers.member.member.dto.response.MemberIdWithPointResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberPointResponse {
+
+    private String code;
+    private String msg;
+    private MemberIdWithPointResponse data;
+}

--- a/src/main/java/com/developers/member/point/entity/Point.java
+++ b/src/main/java/com/developers/member/point/entity/Point.java
@@ -35,6 +35,16 @@ public class Point extends BaseTimeEntity {
     public Point(Member member, Long point) {
         this.member = member;
         this.point = point;
+    }
 
+    public void increase(Long point) {
+        this.point += point;
+    }
+
+    public void decrease(Long point) {
+        this.point -= point;
+        if(this.point < 0) {
+            this.point = 0L;
+        }
     }
 }

--- a/src/main/java/com/developers/member/point/service/PointService.java
+++ b/src/main/java/com/developers/member/point/service/PointService.java
@@ -1,0 +1,10 @@
+package com.developers.member.point.service;
+
+import com.developers.member.point.dto.request.MemberPointRequest;
+import com.developers.member.point.dto.response.MemberPointResponse;
+
+public interface PointService {
+    MemberPointResponse increasePoint(MemberPointRequest request);
+
+    MemberPointResponse decreasePoint(MemberPointRequest request);
+}

--- a/src/main/java/com/developers/member/point/service/PointServiceImpl.java
+++ b/src/main/java/com/developers/member/point/service/PointServiceImpl.java
@@ -1,0 +1,94 @@
+package com.developers.member.point.service;
+
+import com.developers.member.member.dto.response.MemberIdWithPointResponse;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.repository.MemberRepository;
+import com.developers.member.point.dto.request.MemberPointRequest;
+import com.developers.member.point.dto.response.MemberPointResponse;
+import com.developers.member.point.repository.PointRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class PointServiceImpl implements PointService {
+    private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
+
+    @Transactional
+    @Override
+    public MemberPointResponse increasePoint(MemberPointRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if (member.isPresent()) {
+                member.get().increasePoint(10L);
+                MemberIdWithPointResponse res = MemberIdWithPointResponse.builder()
+                        .memberId(member.get().getMemberId())
+                        .point(member.get().getPoint().getPoint())
+                        .build();
+                return MemberPointResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 점수를 적립하였습니다.")
+                        .data(res)
+                        .build();
+            } else {
+                return MemberPointResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberPointResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("점수를 적립하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public MemberPointResponse decreasePoint(MemberPointRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if (member.isPresent()) {
+                if(member.get().getPoint().getPoint() < 30L) {
+                    return MemberPointResponse.builder()
+                            .code(HttpStatus.BAD_REQUEST.toString())
+                            .msg("보유한 포인트가 부족하여 요청을 처리할 수 없습니다.")
+                            .data(null)
+                            .build();
+                }
+                member.get().decreasePoint(30L);
+                MemberIdWithPointResponse res = MemberIdWithPointResponse.builder()
+                        .memberId(member.get().getMemberId())
+                        .point(member.get().getPoint().getPoint())
+                        .build();
+                return MemberPointResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 점수를 차감하였습니다.")
+                        .data(res)
+                        .build();
+            } else {
+                return MemberPointResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberPointResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("점수를 차감하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/developers/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/developers/member/repository/MemberRepositoryTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaConfig.class)
-@ActiveProfiles("local")
+@ActiveProfiles("prod")
 public class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/developers/member/repository/PointRepositoryTest.java
+++ b/src/test/java/com/developers/member/repository/PointRepositoryTest.java
@@ -25,13 +25,16 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaConfig.class)
-@ActiveProfiles("local")
+@ActiveProfiles("prod")
 public class PointRepositoryTest {
     @Autowired private PointRepository pointRepository;
     @Autowired private MemberRepository memberRepository;
 
-    @BeforeEach
-    public void setUp() {
+
+    @DisplayName("문제 풀이를 통한 포인트 적립")
+    @Test
+    public void increasePoint() {
+        // given
         Member member = Member.builder()
                 .email("lango@kakao.com")
                 .password("kakao123")
@@ -45,21 +48,8 @@ public class PointRepositoryTest {
                 .point(100L)
                 .build();
         memberRepository.save(member);
-    }
-
-    @AfterEach
-    public void clear() {
-        memberRepository.deleteAll();
-        pointRepository.deleteAll();
-    }
-
-    @DisplayName("문제 풀이를 통한 포인트 적립")
-    @Test
-    public void increasePoint() {
-        // given
-        Long memberId = 1L;
-        Optional<Member> member = memberRepository.findById(memberId);
-        Point point = member.get().getPoint();
+        Optional<Member> saveMember = memberRepository.findById(member.getMemberId());
+        Point point = saveMember.get().getPoint();
         point.increase(10L);
         pointRepository.save(point);
 
@@ -74,9 +64,21 @@ public class PointRepositoryTest {
     @Test
     public void decreasePoint() {
         // given
-        Long memberId = 2L;
-        Optional<Member> member = memberRepository.findById(memberId);
-        Point point = member.get().getPoint();
+        Member member = Member.builder()
+                .email("lango@kakao.com")
+                .password("kakao123")
+                .nickname("lango")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .address("서울특별시 강남구")
+                .introduce("안녕하세요 저는 ...")
+                .point(100L)
+                .build();
+        memberRepository.save(member);
+        Optional<Member> saveMember = memberRepository.findById(member.getMemberId());
+        Point point = saveMember.get().getPoint();
         point.decrease(30L);
         pointRepository.save(point);
 

--- a/src/test/java/com/developers/member/repository/PointRepositoryTest.java
+++ b/src/test/java/com/developers/member/repository/PointRepositoryTest.java
@@ -1,0 +1,89 @@
+package com.developers.member.repository;
+
+import com.developers.member.config.JpaConfig;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.entity.Role;
+import com.developers.member.member.entity.Type;
+import com.developers.member.member.repository.MemberRepository;
+import com.developers.member.point.entity.Point;
+import com.developers.member.point.repository.PointRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+//@SpringBootTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("local")
+public class PointRepositoryTest {
+    @Autowired private PointRepository pointRepository;
+    @Autowired private MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setUp() {
+        Member member = Member.builder()
+                .email("lango@kakao.com")
+                .password("kakao123")
+                .nickname("lango")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .address("서울특별시 강남구")
+                .introduce("안녕하세요 저는 ...")
+                .point(100L)
+                .build();
+        memberRepository.save(member);
+    }
+
+    @AfterEach
+    public void clear() {
+        memberRepository.deleteAll();
+        pointRepository.deleteAll();
+    }
+
+    @DisplayName("문제 풀이를 통한 포인트 적립")
+    @Test
+    public void increasePoint() {
+        // given
+        Long memberId = 1L;
+        Optional<Member> member = memberRepository.findById(memberId);
+        Point point = member.get().getPoint();
+        point.increase(10L);
+        pointRepository.save(point);
+
+        // when
+        Optional<Point> result = pointRepository.findById(point.getPointId());
+
+        // then
+        assertThat(result.get().getPoint()).isEqualTo(110L);
+    }
+
+    @DisplayName("멘토링룸 신청을 통한 포인트 차감")
+    @Test
+    public void decreasePoint() {
+        // given
+        Long memberId = 2L;
+        Optional<Member> member = memberRepository.findById(memberId);
+        Point point = member.get().getPoint();
+        point.decrease(30L);
+        pointRepository.save(point);
+
+        // when
+        Optional<Point> result = pointRepository.findById(point.getPointId());
+
+        // then
+        assertThat(result.get().getPoint()).isEqualTo(70L);
+    }
+}

--- a/src/test/java/com/developers/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/service/MemberServiceTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.when;
 public class MemberServiceTest {
     @Mock
     private MemberRepository memberRepository;
-
     @Mock
     private PasswordEncoder passwordEncoder;
     @InjectMocks

--- a/src/test/java/com/developers/member/service/PointServiceTest.java
+++ b/src/test/java/com/developers/member/service/PointServiceTest.java
@@ -1,0 +1,92 @@
+package com.developers.member.service;
+
+import com.developers.member.member.dto.response.MemberIdWithPointResponse;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.entity.Role;
+import com.developers.member.member.entity.Type;
+import com.developers.member.member.repository.MemberRepository;
+import com.developers.member.point.dto.request.MemberPointRequest;
+import com.developers.member.point.dto.response.MemberPointResponse;
+import com.developers.member.point.repository.PointRepository;
+import com.developers.member.point.service.PointServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PointServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PointRepository pointRepository;
+    @InjectMocks
+    private PointServiceImpl pointService;
+
+    @DisplayName("문제 정답 풀이를 통한 포인트 적립")
+    @Test
+    public void increasePoint() {
+        // given
+        MemberPointRequest request = MemberPointRequest.builder()
+                .memberId(1L)
+                .build();
+        Member member = Member.builder()
+                .email("test001@kakao.com")
+                .password("kakao123")
+                .nickname("test001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .point(100L)
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+
+        // when
+        MemberPointResponse response = pointService.increasePoint(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 점수를 적립하였습니다.");
+        assertThat(response.getData()).isInstanceOf(MemberIdWithPointResponse.class);
+        assertThat(response.getData().getPoint()).isEqualTo(110L);
+    }
+
+    @DisplayName("멘토링룸 일정 신청을 통한 포인트 차감")
+    @Test
+    public void decreasePoint() {
+        // given
+        MemberPointRequest request = MemberPointRequest.builder()
+                .memberId(1L)
+                .build();
+        Member member = Member.builder()
+                .email("test001@kakao.com")
+                .password("kakao123")
+                .nickname("test001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .point(100L)
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+
+        // when
+        MemberPointResponse response = pointService.decreasePoint(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 점수를 차감하였습니다.");
+        assertThat(response.getData()).isInstanceOf(MemberIdWithPointResponse.class);
+        assertThat(response.getData().getPoint()).isEqualTo(70L);
+    }
+}


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 점수 적립 및 차감 API 개발 완료

<br>

## 💡 Key Changes
- 점수 적립 API의 경우 10점씩 포인트를 적립하도록 구현하였습니다.
    - 문제 풀이 서비스에서 정답을 맞출 경우 해당 API가 호출되어야 합니다.
- 점수 차감 API의 경우 30점씩 포인트를 차감시키도록 구현하였습니다.
    - 멘토링 서비스에서 사용자가 원하는 멘토링룸 일정에 신청할 때 해당 API가 호출되어야 합니다.
    - 점수 차감은 30점씩 차감되므로, 30점 미만이거나 음수가 되지 않도록 예외 처리 구문을 추가하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 

---

close #5
