### PR TITLE
[Feat] 사용자 이력 및 경력정보 관련 API 개발 완료

### DIFF
--- a/src/main/java/com/developers/member/career/controller/CareerController.java
+++ b/src/main/java/com/developers/member/career/controller/CareerController.java
@@ -1,0 +1,45 @@
+package com.developers.member.career.controller;
+
+import com.developers.member.career.dto.request.MemberCareerUpdateRequest;
+import com.developers.member.career.dto.response.MemberCareerGetResponse;
+import com.developers.member.career.dto.request.MemberCareerSaveRequest;
+import com.developers.member.career.dto.response.MemberCareerResponse;
+import com.developers.member.career.service.CareerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Log4j2
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/career")
+public class CareerController {
+    private final CareerService careerService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberCareerGetResponse> getCareerInfo(@PathVariable Long memberId) {
+        MemberCareerGetResponse response = careerService.getCareerInfo(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<MemberCareerResponse> saveCareer(@Valid @RequestBody MemberCareerSaveRequest request) {
+        MemberCareerResponse response = careerService.saveCareer(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<MemberCareerResponse> updateCareer(@Valid @RequestBody MemberCareerUpdateRequest request) {
+        MemberCareerResponse response = careerService.updateCareer(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/{careerId}")
+    public ResponseEntity<MemberCareerResponse> removeCareer(@Valid @PathVariable Long careerId) {
+        MemberCareerResponse response = careerService.removeCareer(careerId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/developers/member/career/dto/request/MemberCareerSaveRequest.java
+++ b/src/main/java/com/developers/member/career/dto/request/MemberCareerSaveRequest.java
@@ -1,0 +1,25 @@
+package com.developers.member.career.dto.request;
+
+import com.developers.member.career.dto.response.MemberOfCareer;
+import com.developers.member.career.entity.Career;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@Getter
+public class MemberCareerSaveRequest {
+    private String company;
+    private LocalDate careerStart;
+    private LocalDate careerEnd;
+
+    public Career toEntity() {
+        return Career.builder()
+                .company(company)
+                .start(careerStart)
+                .end(careerEnd)
+                .build();
+    }
+}

--- a/src/main/java/com/developers/member/career/dto/request/MemberCareerUpdateRequest.java
+++ b/src/main/java/com/developers/member/career/dto/request/MemberCareerUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.developers.member.career.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class MemberCareerUpdateRequest {
+    private Long careerId;
+    private String company;
+    private LocalDate careerStart;
+    private LocalDate careerEnd;
+}

--- a/src/main/java/com/developers/member/career/dto/response/CareerIdResponse.java
+++ b/src/main/java/com/developers/member/career/dto/response/CareerIdResponse.java
@@ -1,0 +1,10 @@
+package com.developers.member.career.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CareerIdResponse {
+    private Long careerId;
+}

--- a/src/main/java/com/developers/member/career/dto/response/CareerInfo.java
+++ b/src/main/java/com/developers/member/career/dto/response/CareerInfo.java
@@ -1,0 +1,17 @@
+package com.developers.member.career.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Builder
+@Getter
+@ToString
+public class CareerInfo {
+    private String introduce;
+    private String positions;
+    private String skills;
+    private List<MemberOfCareer> careerList;
+}

--- a/src/main/java/com/developers/member/career/dto/response/MemberCareerGetResponse.java
+++ b/src/main/java/com/developers/member/career/dto/response/MemberCareerGetResponse.java
@@ -1,0 +1,13 @@
+package com.developers.member.career.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberCareerGetResponse {
+    private String code;
+    private String msg;
+    private CareerInfo data;
+}
+

--- a/src/main/java/com/developers/member/career/dto/response/MemberCareerResponse.java
+++ b/src/main/java/com/developers/member/career/dto/response/MemberCareerResponse.java
@@ -1,0 +1,12 @@
+package com.developers.member.career.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberCareerResponse {
+    private String code;
+    private String msg;
+    private CareerIdResponse data;
+}

--- a/src/main/java/com/developers/member/career/dto/response/MemberOfCareer.java
+++ b/src/main/java/com/developers/member/career/dto/response/MemberOfCareer.java
@@ -1,0 +1,14 @@
+package com.developers.member.career.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class MemberOfCareer {
+    private String company;
+    private LocalDate careerStart;
+    private LocalDate careerEnd;
+}

--- a/src/main/java/com/developers/member/career/entity/Career.java
+++ b/src/main/java/com/developers/member/career/entity/Career.java
@@ -1,0 +1,59 @@
+package com.developers.member.career.entity;
+
+import com.developers.member.common.entity.BaseTimeEntity;
+import com.developers.member.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"member"})
+@SQLDelete(sql = "UPDATE career SET deleted = true WHERE career_id = ?")
+@Where(clause = "deleted = false")
+@Table(name = "career")
+@Entity
+public class Career extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "career_id", nullable = false)
+    private Long careerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "career_start", nullable = false)
+    private LocalDate start;
+
+    @Column(name = "career_end", nullable = false)
+    private LocalDate end;
+
+    @Column(name = "company", nullable = false)
+    private String company;
+
+    @Builder
+    public Career(Member member, LocalDate start, LocalDate end, String company) {
+        this.member = member;
+        this.start = start;
+        this.end = end;
+        this.company = company;
+    }
+
+    public void updateCompany(String company) {
+        this.company = company;
+    }
+    public void changeStartDate(LocalDate start) {
+        this.start = start;
+    }
+    public void changeEndDate(LocalDate end) {
+        this.end = end;
+    }
+}

--- a/src/main/java/com/developers/member/career/repository/CareerRepository.java
+++ b/src/main/java/com/developers/member/career/repository/CareerRepository.java
@@ -1,0 +1,11 @@
+package com.developers.member.career.repository;
+
+import com.developers.member.career.entity.Career;
+import com.developers.member.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+    List<Career> findByMember(Member member);
+}

--- a/src/main/java/com/developers/member/career/service/CareerService.java
+++ b/src/main/java/com/developers/member/career/service/CareerService.java
@@ -1,0 +1,16 @@
+package com.developers.member.career.service;
+
+import com.developers.member.career.dto.request.MemberCareerSaveRequest;
+import com.developers.member.career.dto.request.MemberCareerUpdateRequest;
+import com.developers.member.career.dto.response.MemberCareerGetResponse;
+import com.developers.member.career.dto.response.MemberCareerResponse;
+
+public interface CareerService {
+    MemberCareerGetResponse getCareerInfo(Long memberId);
+
+    MemberCareerResponse saveCareer(MemberCareerSaveRequest request);
+
+    MemberCareerResponse updateCareer(MemberCareerUpdateRequest request);
+
+    MemberCareerResponse removeCareer(Long careerId);
+}

--- a/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
+++ b/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
@@ -1,0 +1,153 @@
+package com.developers.member.career.service;
+
+import com.developers.member.career.dto.request.MemberCareerSaveRequest;
+import com.developers.member.career.dto.request.MemberCareerUpdateRequest;
+import com.developers.member.career.dto.response.*;
+import com.developers.member.career.entity.Career;
+import com.developers.member.career.repository.CareerRepository;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class CareerServiceImpl implements CareerService {
+    private final CareerRepository careerRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberCareerGetResponse getCareerInfo(Long memberId) {
+        try {
+            Optional<Member> member = memberRepository.findById(memberId);
+            if (member.isPresent()) {
+                List<Career> careers = careerRepository.findByMember(member.get());
+                List<MemberOfCareer> careerList = new ArrayList<>();
+                for(Career career : careers) {
+                    MemberOfCareer m = MemberOfCareer.builder()
+                            .company(career.getCompany())
+                            .careerStart(career.getStart())
+                            .careerEnd(career.getEnd())
+                            .build();
+                    careerList.add(m);
+                }
+                CareerInfo careerInfo = CareerInfo.builder()
+                        .introduce(member.get().getIntroduce())
+                        .positions(member.get().getPosition())
+                        .skills(member.get().getSkills())
+                        .careerList(careerList)
+                        .build();
+                return MemberCareerGetResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 이력 및 경력정보를 조회하였습니다.")
+                        .data(careerInfo)
+                        .build();
+            } else {
+                return MemberCareerGetResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberCareerGetResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("이력 및 경력정보 조회 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Override
+    public MemberCareerResponse saveCareer(MemberCareerSaveRequest request) {
+        try {
+            Career career = request.toEntity();
+            careerRepository.save(career);
+            CareerIdResponse careerId = CareerIdResponse.builder()
+                    .careerId(career.getCareerId())
+                    .build();
+            return MemberCareerResponse.builder()
+                    .code(HttpStatus.OK.toString())
+                    .msg("정상적으로 경력정보가 등록되었습니다.")
+                    .data(careerId)
+                    .build();
+        } catch (Exception e) {
+            return MemberCareerResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("경력정보를 등록하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public MemberCareerResponse updateCareer(MemberCareerUpdateRequest request) {
+        try {
+            Optional<Career> career = careerRepository.findById(request.getCareerId());
+            if (career.isPresent()) {
+                career.get().updateCompany(request.getCompany());
+                career.get().changeStartDate(request.getCareerStart());
+                career.get().changeEndDate(request.getCareerEnd());
+                CareerIdResponse careerId = CareerIdResponse.builder()
+                        .careerId(career.get().getCareerId())
+                        .build();
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 경력정보가 변경되었습니다.")
+                        .data(careerId)
+                        .build();
+            } else {
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 경력정보입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberCareerResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("경력정보를 변경하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Override
+    public MemberCareerResponse removeCareer(Long careerId) {
+        try {
+            Optional<Career> career = careerRepository.findById(careerId);
+            if (career.isPresent()) {
+                careerRepository.deleteById(career.get().getCareerId());
+                CareerIdResponse deleteCareerId = CareerIdResponse.builder()
+                        .careerId(careerId)
+                        .build();
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 경력정보를 삭제하였습니다.")
+                        .data(deleteCareerId)
+                        .build();
+            } else {
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 경력정보입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberCareerResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("경력정보를 삭제하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/developers/member/member/controller/ResumeController.java
+++ b/src/main/java/com/developers/member/member/controller/ResumeController.java
@@ -1,0 +1,27 @@
+package com.developers.member.member.controller;
+
+import com.developers.member.member.dto.request.MemberResumeSaveRequest;
+import com.developers.member.member.dto.response.MemberResumeSaveResponse;
+import com.developers.member.member.repository.MemberRepository;
+import com.developers.member.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/resume")
+public class ResumeController {
+    private final MemberService memberService;
+
+    @PatchMapping
+    public ResponseEntity<MemberResumeSaveResponse> saveMemberResume(@Valid @RequestBody MemberResumeSaveRequest request) {
+        MemberResumeSaveResponse response = memberService.saveMemberResume(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/developers/member/member/dto/request/MemberResumeSaveRequest.java
+++ b/src/main/java/com/developers/member/member/dto/request/MemberResumeSaveRequest.java
@@ -1,0 +1,13 @@
+package com.developers.member.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberResumeSaveRequest {
+    private Long memberId;
+    private String introduce;
+    private String positions;
+    private String skills;
+}

--- a/src/main/java/com/developers/member/member/dto/response/MemberResumeSaveResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberResumeSaveResponse.java
@@ -1,0 +1,12 @@
+package com.developers.member.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberResumeSaveResponse {
+    private String code;
+    private String msg;
+    private MemberIdResponse data;
+}

--- a/src/main/java/com/developers/member/member/entity/Member.java
+++ b/src/main/java/com/developers/member/member/entity/Member.java
@@ -104,6 +104,12 @@ public class Member extends BaseTimeEntity {
     public void updateIntroduce(String introduce) {
         this.introduce = introduce;
     }
+    public void updatePosition(String position) {
+        this.position = position;
+    }
+    public void updateSkills(String skills) {
+        this.skills = skills;
+    }
     public void increasePoint(Long point) {
         this.point.increase(point);
     }

--- a/src/main/java/com/developers/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/developers/member/member/repository/MemberRepository.java
@@ -14,4 +14,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByNickname(String nickname);
+
 }

--- a/src/main/java/com/developers/member/member/service/MemberService.java
+++ b/src/main/java/com/developers/member/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.developers.member.member.service;
 
-import com.developers.member.member.dto.request.MemberRegisterRequest;
-import com.developers.member.member.dto.request.NicknameUpdateRequest;
-import com.developers.member.member.dto.request.PasswordChangeRequest;
-import com.developers.member.member.dto.request.ProfileImageUpdateRequest;
+import com.developers.member.member.dto.request.*;
 import com.developers.member.member.dto.response.*;
 
 public interface MemberService {
@@ -21,4 +18,6 @@ public interface MemberService {
     ProfileImageUpdateResponse updateProfileImg(ProfileImageUpdateRequest request);
 
     PasswordChangeResponse changePassword(PasswordChangeRequest request);
+
+    MemberResumeSaveResponse saveMemberResume(MemberResumeSaveRequest request);
 }

--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -1,9 +1,6 @@
 package com.developers.member.member.service;
 
-import com.developers.member.member.dto.request.MemberRegisterRequest;
-import com.developers.member.member.dto.request.NicknameUpdateRequest;
-import com.developers.member.member.dto.request.PasswordChangeRequest;
-import com.developers.member.member.dto.request.ProfileImageUpdateRequest;
+import com.developers.member.member.dto.request.*;
 import com.developers.member.member.dto.response.*;
 import com.developers.member.member.entity.Member;
 import com.developers.member.member.repository.MemberRepository;
@@ -206,6 +203,37 @@ public class MemberServiceImpl implements MemberService {
             return PasswordChangeResponse.builder()
                     .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
                     .msg("비밀번호를 변경하던 중 문제가 발생하였습니다.")
+                    .data(null)
+                    .build();
+        }
+    }
+
+    @Transactional
+    @Override
+    public MemberResumeSaveResponse saveMemberResume(MemberResumeSaveRequest request) {
+        try {
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if (member.isPresent()) {
+                member.get().updateIntroduce(request.getIntroduce());
+                member.get().updatePosition(request.getPositions());
+                member.get().updateSkills(request.getSkills());
+                MemberIdResponse memberId = MemberIdResponse.builder().memberId(member.get().getMemberId()).build();
+                return MemberResumeSaveResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 이력정보를 등록하였습니다.")
+                        .data(memberId)
+                        .build();
+            } else {
+                return MemberResumeSaveResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
+        } catch (Exception e) {
+            return MemberResumeSaveResponse.builder()
+                    .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())
+                    .msg("이력정보를 등록하던 중 문제가 발생하였습니다.")
                     .data(null)
                     .build();
         }

--- a/src/main/java/com/developers/member/skill/Skill.java
+++ b/src/main/java/com/developers/member/skill/Skill.java
@@ -1,0 +1,25 @@
+package com.developers.member.skill;
+
+
+import com.developers.member.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@NoArgsConstructor
+@Getter
+@SQLDelete(sql = "UPDATE skill SET deleted = true WHERE skill_id = ?")
+@Where(clause = "deleted = false")
+@Table(name = "skill")
+@Entity
+public class Skill extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "skill_id")
+    private Long skillId;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
+++ b/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
@@ -1,0 +1,154 @@
+package com.developers.member.career.repository;
+
+import com.developers.member.career.entity.Career;
+import com.developers.member.config.JpaConfig;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.entity.Role;
+import com.developers.member.member.entity.Type;
+import com.developers.member.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+//@SpringBootTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("prod")
+public class CareerRepositoryTest {
+    @Autowired
+    private CareerRepository careerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("사용자 경력정보 저장")
+    @Test
+    public void save() {
+        // given
+        LocalDate currentDate = LocalDate.now();
+        Member member = Member.builder()
+                .email("test001@kakao.com")
+                .password("kakao123")
+                .nickname("test001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .address("서울특별시 강남구")
+                .introduce("안녕하세요 저는 ...")
+                .position("Software Engineer,Backend Engineer")
+                .skills("Spring,Java,MySQL")
+                .point(100L)
+                .build();
+        Career career1 = Career.builder()
+                .member(member)
+                .company("카카오")
+                .start(currentDate)
+                .end(currentDate)
+                .build();
+        Career career2 = Career.builder()
+                .member(member)
+                .company("네이버")
+                .start(currentDate)
+                .end(currentDate)
+                .build();
+
+        // when
+        memberRepository.save(member);
+        careerRepository.save(career1);
+        careerRepository.save(career2);
+        List<Career> memberCareerList = careerRepository.findByMember(member);
+        Career result1 = memberCareerList.get(0);
+        Career result2 = memberCareerList.get(1);
+
+        // then
+        assertThat(result1.getCompany()).isEqualTo("카카오");
+        assertThat(result2.getCompany()).isEqualTo("네이버");
+    }
+
+    @DisplayName("사용자 경력정보 수정")
+    @Transactional
+    @Test
+    public void update() {
+        // given
+        LocalDate currentDate = LocalDate.now();
+        Member member = Member.builder()
+                .email("test002@kakao.com")
+                .password("kakao123")
+                .nickname("test002")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .address("서울특별시 서초구")
+                .introduce("안녕하세요 저는 프론트엔드 개발자입지다.")
+                .position("Software Engineer,Frontend Engineer")
+                .skills("React,JS,Redux,Recoil")
+                .point(100L)
+                .build();
+        Career career = Career.builder()
+                .member(member)
+                .company("카카오")
+                .start(currentDate)
+                .end(currentDate)
+                .build();
+
+        // when
+        memberRepository.save(member);
+        Career saveCareer = careerRepository.save(career);
+        saveCareer.updateCompany("카카오페이");
+        List<Career> memberCareerList = careerRepository.findByMember(member);
+        Career result = memberCareerList.get(0);
+
+        // then
+        assertThat(result.getCompany()).isEqualTo("카카오페이");
+    }
+
+    @DisplayName("사용자 경력정보 삭제")
+    @Test
+    public void removeMemberCareer() {
+        // given
+        LocalDate currentDate = LocalDate.now();
+        Member member = Member.builder()
+                .email("test002@kakao.com")
+                .password("kakao123")
+                .nickname("test002")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .address("서울특별시 서초구")
+                .introduce("안녕하세요 저는 프론트엔드 개발자입지다.")
+                .position("Software Engineer,Frontend Engineer")
+                .skills("React,JS,Redux,Recoil")
+                .point(100L)
+                .build();
+        Career career = Career.builder()
+                .member(member)
+                .company("카카오")
+                .start(currentDate)
+                .end(currentDate)
+                .build();
+
+        // when
+        memberRepository.save(member);
+        Career saveCareer = careerRepository.save(career);
+        careerRepository.deleteById(saveCareer.getCareerId());
+        List<Career> result = careerRepository.findAll();
+
+        // then
+        assertThat(result.size()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/developers/member/career/service/CareerServiceTest.java
+++ b/src/test/java/com/developers/member/career/service/CareerServiceTest.java
@@ -1,0 +1,155 @@
+package com.developers.member.career.service;
+
+import com.developers.member.career.dto.request.MemberCareerSaveRequest;
+import com.developers.member.career.dto.request.MemberCareerUpdateRequest;
+import com.developers.member.career.dto.response.CareerIdResponse;
+import com.developers.member.career.dto.response.CareerInfo;
+import com.developers.member.career.dto.response.MemberCareerGetResponse;
+import com.developers.member.career.dto.response.MemberCareerResponse;
+import com.developers.member.career.entity.Career;
+import com.developers.member.career.repository.CareerRepository;
+import com.developers.member.member.entity.Member;
+import com.developers.member.member.entity.Role;
+import com.developers.member.member.entity.Type;
+import com.developers.member.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CareerServiceTest {
+    @Mock
+    private CareerRepository careerRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @InjectMocks
+    private CareerServiceImpl careerService;
+
+    @DisplayName("사용자 경력정보 등록")
+    @Test
+    public void saveCareer() {
+        LocalDate curruntDate = LocalDate.now();
+        // given
+        MemberCareerSaveRequest request = MemberCareerSaveRequest.builder()
+                .company("마이다스 아이티")
+                .careerStart(curruntDate)
+                .careerEnd(curruntDate)
+                .build();
+        Career career = request.toEntity();
+        when(careerRepository.save(any())).thenReturn(career);
+
+        // when
+        MemberCareerResponse response = careerService.saveCareer(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 경력정보가 등록되었습니다.");
+        assertThat(response.getData()).isInstanceOf(CareerIdResponse.class);
+        assertThat(response.getData().getCareerId()).isEqualTo(career.getCareerId());
+    }
+
+    @DisplayName("사용자의 이력 및 경력 정보 모두 조회")
+    @Test
+    public void getCareerInfo() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+                .email("career001@kakao.com")
+                .password("kakao123")
+                .nickname("career001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .profileImageUrl("/root/1")
+                .isMentor(false)
+                .point(100L)
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+        List<Career> careerList = new ArrayList<>();
+        Career career1 = Career.builder()
+                .company("우아한형제들 정산서비스팀")
+                .start(LocalDate.now())
+                .end(LocalDate.now())
+                .build();
+        Career career2 = Career.builder()
+                .company("네이버 파이넨셜")
+                .start(LocalDate.now())
+                .end(LocalDate.now())
+                .build();
+        careerList.add(career1);
+        careerList.add(career2);
+        when(careerRepository.findByMember(any())).thenReturn(careerList);
+
+        // when
+        MemberCareerGetResponse response = careerService.getCareerInfo(memberId);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 이력 및 경력정보를 조회하였습니다.");
+        assertThat(response.getData()).isInstanceOf(CareerInfo.class);
+        assertThat(response.getData().getCareerList().get(0).getCompany()).isEqualTo(career1.getCompany());
+        assertThat(response.getData().getCareerList().get(1).getCompany()).isEqualTo(career2.getCompany());
+    }
+
+    @DisplayName("사용자의 특정 경력정보 변경")
+    @Test
+    public void updateCareer() {
+        // given
+        MemberCareerUpdateRequest request = MemberCareerUpdateRequest.builder()
+                .careerId(2L)
+                .company("카카오 페이")
+                .careerStart(LocalDate.now())
+                .careerEnd(LocalDate.now())
+                .build();
+        Career career = Career.builder()
+                .company("카카오")
+                .start(LocalDate.now())
+                .end(LocalDate.now())
+                .build();
+        when(careerRepository.findById(any())).thenReturn(Optional.of(career));
+
+        // when
+        MemberCareerResponse response = careerService.updateCareer(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 경력정보가 변경되었습니다.");
+        assertThat(response.getData()).isInstanceOf(CareerIdResponse.class);
+    }
+
+    @DisplayName("사용자의 특정 경력정보 삭제")
+    @Test
+    public void removeCareer() {
+        // given
+        Long careerId = 1L;
+        Career career = Career.builder()
+                .company("카카오")
+                .start(LocalDate.now())
+                .end(LocalDate.now())
+                .build();
+        when(careerRepository.findById(any())).thenReturn(Optional.of(career));
+
+        // when
+        MemberCareerResponse response = careerService.removeCareer(1L);
+
+        // then
+        assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+        assertThat(response.getMsg()).isEqualTo("정상적으로 경력정보를 삭제하였습니다.");
+        assertThat(response.getData()).isInstanceOf(CareerIdResponse.class);
+    }
+
+
+
+}

--- a/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.developers.member.repository;
+package com.developers.member.member.repository;
 
 import com.developers.member.config.JpaConfig;
 import com.developers.member.member.entity.Member;
@@ -51,6 +51,8 @@ public class MemberRepositoryTest {
                 .isMentor(false)
                 .address("서울특별시 강남구")
                 .introduce("안녕하세요 저는 ...")
+                .position("Software Engineer,Backend Engineer")
+                .skills("Spring,Java,MySQL")
                 .point(100L)
                 .build();
         memberRepository.save(member);
@@ -263,5 +265,34 @@ public class MemberRepositoryTest {
 
         // then
         Assertions.assertEquals(result.getPassword(), "kakaocloudschool123");
+    }
+
+    @DisplayName("이력정보 등록 및 수정 - 간단소개글, 직무, 주요기술")
+    @Test
+    public void updateMemberResume() {
+        // given
+        Member member = Member.builder()
+                .email("resume001@kakao.com")
+                .password("kakao123")
+                .nickname("resume001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(false)
+                .profileImageUrl("/root/resume001/1")
+                .point(100L)
+                .build();
+        Member saveMember = memberRepository.save(member);
+
+        // when
+        saveMember.updateIntroduce("안녕하세요 저는 백엔드 개발자 xxx 입니다.");
+        saveMember.updatePosition("웹 개발자,소프트웨어 엔지니어,자바 개발자");
+        saveMember.updateSkills("Java,Spring,MySQL");
+        Member result = memberRepository.save(member);
+
+        // then
+        assertThat(result.getIntroduce()).isEqualTo(saveMember.getIntroduce());
+        assertThat(result.getPosition()).isEqualTo(saveMember.getPosition());
+        assertThat(result.getSkills()).isEqualTo(saveMember.getSkills());
+
     }
 }

--- a/src/test/java/com/developers/member/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/member/service/MemberServiceTest.java
@@ -1,4 +1,4 @@
-package com.developers.member.service;
+package com.developers.member.member.service;
 
 import com.developers.member.member.dto.request.MemberRegisterRequest;
 import com.developers.member.member.dto.request.NicknameUpdateRequest;
@@ -9,10 +9,6 @@ import com.developers.member.member.entity.Member;
 import com.developers.member.member.entity.Role;
 import com.developers.member.member.entity.Type;
 import com.developers.member.member.repository.MemberRepository;
-import com.developers.member.member.service.MemberServiceImpl;
-import com.developers.member.point.entity.Point;
-import com.developers.member.point.repository.PointRepository;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +40,6 @@ public class MemberServiceTest {
     private MemberServiceImpl memberService;
 
     @DisplayName("사용자 회원가입")
-    @Transactional
     @Test
     public void register() {
         // given

--- a/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
+++ b/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.developers.member.repository;
+package com.developers.member.point.repository;
 
 import com.developers.member.config.JpaConfig;
 import com.developers.member.member.entity.Member;

--- a/src/test/java/com/developers/member/point/service/PointServiceTest.java
+++ b/src/test/java/com/developers/member/point/service/PointServiceTest.java
@@ -1,4 +1,4 @@
-package com.developers.member.service;
+package com.developers.member.point.service;
 
 import com.developers.member.member.dto.response.MemberIdWithPointResponse;
 import com.developers.member.member.entity.Member;


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 이력 및 경력정보 관련 API 개발 완료

<br>

## 💡 Key Changes
- 사용자의 커리어정보 화면에서 호출할 수 있는 API를 개발하였습니다.
    - 이력 정보중 간단소개글, 원하는 직무, 주요 기술란을 입력후 등록할 수 있는 API를 개발 완료하였습니다.
    - 이력 정보중 경력정보의 경우 사용자와 1대다 관계를 가지기에 별도의 엔티티로 등록,수정,삭제 할 수 있는 API를 개발하였습니다.
- 해당 API와 관련된 테스트 코드를 작성 완료하였습니다.
    - `CareerRepositoryTest, CareerServiceTest`


<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 

---

close #6
