### PR TITLE
[Fix] 회원가입 비밀번호 암호화 누락 사항 수정

### DIFF
--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
@@ -25,12 +26,13 @@ import java.util.Optional;
 @Service
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
-    private final CareerRepository careerRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public MemberRegisterResponse register(MemberRegisterRequest request) {
         try {
             Member member = request.toEntity();
+            member.changePassword(passwordEncoder.encode(member.getPassword()));
             Long saveMemberId = memberRepository.save(member).getMemberId();
             MemberIdWithPointResponse response = MemberIdWithPointResponse.builder()
                     .memberId(saveMemberId)

--- a/src/test/java/com/developers/member/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/member/service/MemberServiceTest.java
@@ -46,7 +46,7 @@ public class MemberServiceTest {
         MemberRegisterRequest request = MemberRegisterRequest.builder()
                 .email("test1@kakao.com")
                 .nickname("test1")
-                .password("kakao123")
+                .password(passwordEncoder.encode("kakao123"))
                 .profileImageUrl("/root/1")
                 .build();
         Member member = request.toEntity();


### PR DESCRIPTION
## 🤔 Motivation
- 회원가입 비밀번호 암호화 누락 사항 수정

<br>

## 💡 Key Changes
- 사용자 회원가입시 입력한 비밀번호를 암호화하여 저장해야 하는데, 암호화를 하지 않고 저장하는 문제가 발생하였습니다.
- 이를 위해 회원가입시 사용자의 비밀번호를 BCypt를 이용해 암호화하여 DB에 저장하도록 수정하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
