### PR TITLE
[HotFix] 인증서버 운영을 위한 테스트코드 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: member-prod
+    active: prod
     group:
       local: member-local
       dev: member-dev

--- a/src/test/java/com/developers/member/badge/controller/BadgeControllerTest.java
+++ b/src/test/java/com/developers/member/badge/controller/BadgeControllerTest.java
@@ -7,8 +7,6 @@ import com.developers.member.badge.entity.Badges;
 import com.developers.member.badge.service.BadgeService;
 import com.developers.member.member.dto.response.MemberIdResponse;
 import com.developers.member.member.dto.response.MemberIdWithPointResponse;
-import com.developers.member.point.dto.request.MemberPointRequest;
-import com.developers.member.point.dto.response.MemberPointResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -37,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(BadgeController.class)
+@WithMockUser(roles = "USER")
 public class BadgeControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/developers/member/badge/repository/BadgeRepositoryTest.java
+++ b/src/test/java/com/developers/member/badge/repository/BadgeRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -26,7 +27,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaConfig.class)
-@ActiveProfiles("prod")
+@ActiveProfiles("member-prod")
+@WithMockUser(roles = "USER")
 public class BadgeRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/developers/member/badge/service/BadgeServiceTest.java
+++ b/src/test/java/com/developers/member/badge/service/BadgeServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@WithMockUser(roles = "USER")
 public class BadgeServiceTest {
     @Mock
     MyBadgeRepository myBadgeRepository;

--- a/src/test/java/com/developers/member/career/controller/CareerControllerTest.java
+++ b/src/test/java/com/developers/member/career/controller/CareerControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(CareerController.class)
+@WithMockUser(roles = "USER")
 public class CareerControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
+++ b/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
@@ -26,7 +27,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaConfig.class)
-@ActiveProfiles("prod")
+@ActiveProfiles("member-prod")
+@WithMockUser(roles = "USER")
 public class CareerRepositoryTest {
     @Autowired
     private CareerRepository careerRepository;

--- a/src/test/java/com/developers/member/career/service/CareerServiceTest.java
+++ b/src/test/java/com/developers/member/career/service/CareerServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@WithMockUser(roles = "USER")
 public class CareerServiceTest {
     @Mock
     private CareerRepository careerRepository;

--- a/src/test/java/com/developers/member/member/controller/ProfileControllerTest.java
+++ b/src/test/java/com/developers/member/member/controller/ProfileControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -32,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ProfileController.class)
+@WithMockUser(roles = "USER")
 public class ProfileControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/developers/member/member/controller/RegisterControllerTest.java
+++ b/src/test/java/com/developers/member/member/controller/RegisterControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -32,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(RegisterController.class)
+@WithMockUser(roles = "USER")
 public class RegisterControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -65,7 +67,7 @@ public class RegisterControllerTest {
         given(memberService.register(any())).willReturn(response);
 
         // when
-        mockMvc.perform(post("/api/member/register")
+        mockMvc.perform(post("/api/auth/register")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
@@ -94,7 +96,7 @@ public class RegisterControllerTest {
         given(memberService.removeMember(any())).willReturn(response);
 
         // when
-        mockMvc.perform(delete("/api/member/" + memberId)
+        mockMvc.perform(delete("/api/auth/" + memberId)
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(memberId))

--- a/src/test/java/com/developers/member/member/controller/ResumeControllerTest.java
+++ b/src/test/java/com/developers/member/member/controller/ResumeControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ResumeController.class)
+@WithMockUser(roles = "USER")
 public class ResumeControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -31,13 +32,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 //@SpringBootTest
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, SecurityConfig.class})
-@ActiveProfiles("prod")
+@Import(JpaConfig.class)
+@ActiveProfiles("member-prod")
+@WithMockUser(roles = "USER")
 public class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
     @DisplayName("한명의 회원 데이터 저장")
     @Test
@@ -45,7 +45,7 @@ public class MemberRepositoryTest {
         // given
         Member member = Member.builder()
                 .email("lango@kakao.com")
-                .password(passwordEncoder.encode("kakao123"))
+                .password("kakao123")
                 .nickname("lango")
                 .type(Type.LOCAL)
                 .role(Role.USER)

--- a/src/test/java/com/developers/member/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/member/service/MemberServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.Optional;
 
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.when;
  *
  */
 @ExtendWith(MockitoExtension.class)
+@WithMockUser(roles = "USER")
 public class MemberServiceTest {
     @Mock
     private MemberRepository memberRepository;

--- a/src/test/java/com/developers/member/point/controller/PointControllerTest.java
+++ b/src/test/java/com/developers/member/point/controller/PointControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(PointController.class)
+@WithMockUser(roles = "USER")
 public class PointControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
+++ b/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
@@ -25,7 +26,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaConfig.class)
-@ActiveProfiles("prod")
+@ActiveProfiles("member-prod")
+@WithMockUser(roles = "USER")
 public class PointRepositoryTest {
     @Autowired private PointRepository pointRepository;
     @Autowired private MemberRepository memberRepository;

--- a/src/test/java/com/developers/member/point/service/PointServiceTest.java
+++ b/src/test/java/com/developers/member/point/service/PointServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.Optional;
 
@@ -24,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@WithMockUser(roles = "USER")
 public class PointServiceTest {
     @Mock
     private MemberRepository memberRepository;


### PR DESCRIPTION
## 🤔 Motivation
- 인증서버 운영을 위한 테스트코드 수정

<br>

## 💡 Key Changes
- 시큐리티 설정을 추가하면서 기존의 테스트코드가 실패하는 문제가 발생했습니다.
    - 테스트 메소드들이 시큐리티 권한을 알고 있지 않기 때문에 실패하는 상황임을 인지하였고, `@WithMockUser(roles = "USER")` 설정을 클래스마다 추가하여 테스트 코드를 성공하도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team @soojik @paduck-96 @ITfervor @EagerProgrammer 
