### PR TITLE
[Fix]: 회원가입시 중복 이메일 케이스 예외 처리 

### DIFF
--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -31,12 +31,20 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberRegisterResponse register(MemberRegisterRequest request) {
         try {
-            Member member = request.toEntity();
-            member.changePassword(passwordEncoder.encode(member.getPassword()));
-            Long saveMemberId = memberRepository.save(member).getMemberId();
+            Optional<Member> member = memberRepository.findByEmail(request.getEmail());
+            if (member.isPresent()) {
+                return MemberRegisterResponse.builder()
+                        .code(HttpStatus.BAD_REQUEST.toString())
+                        .msg("이미 가입된 이메일입니다.")
+                        .data(null)
+                        .build();
+            }
+            Member saveMember = request.toEntity();
+            saveMember.changePassword(passwordEncoder.encode(saveMember.getPassword()));
+            Long saveMemberId = memberRepository.save(saveMember).getMemberId();
             MemberIdWithPointResponse response = MemberIdWithPointResponse.builder()
                     .memberId(saveMemberId)
-                    .point(member.getPoint().getPoint())
+                    .point(saveMember.getPoint().getPoint())
                     .build();
             return MemberRegisterResponse.builder()
                     .code(HttpStatus.OK.toString())


### PR DESCRIPTION
## 🤔 Motivation
- 중복 회원가입 상황 해결 

<br>

## 💡 Key Changes
- 회원가입시 중복 이메일로 가입을 할 경우 서버에서 예외가 발생하지만, 클라이언트에게 별다른 예외를 응답으로 주지 않는 상황이 발생하여 이미 가입된 이메일로 회원가입을 요청할 경우 가입을 하지 못함을 응답으로 던져주도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
