### PR TITLE
[Fix] 회원가입 중복 예외 처리 설정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,9 +91,9 @@ pipeline {
         // 이미지 태그 변경 후 메인 브랜치에 푸시
         sh "git config --global user.email ${gitEmail}"
         sh "git config --global user.name ${gitName}"
-        sh "sed -i 's@${dockerHubRegistry}:.*@${dockerHubRegistry}:${currentBuild.number}@g' deploy/deploy-member.yml"
-        sh "chmod +x deploy/deploy-member.yml"
-        sh "git add deploy/deploy-member.yml"
+        sh "sed -i 's@${dockerHubRegistry}:.*@${dockerHubRegistry}:${currentBuild.number}@g' deploy/member/deploy-member.yml"
+        sh "chmod +x deploy/member/deploy-member.yml"
+        sh "git add deploy/member/deploy-member.yml"
         sh "git status"
         sh "git commit -m 'fix:${dockerHubRegistry} ${currentBuild.number} image versioning'"
         sh "git branch -M main"

--- a/src/main/java/com/developers/member/member/dto/response/MemberRegisterResponse.java
+++ b/src/main/java/com/developers/member/member/dto/response/MemberRegisterResponse.java
@@ -14,10 +14,10 @@ import lombok.ToString;
 public class MemberRegisterResponse {
     private String code;
     private String msg;
-    private MemberIdWithPointResponse data;
+    private MemberIdResponse data;
 
     @Builder
-    public MemberRegisterResponse(String code, String msg, MemberIdWithPointResponse data) {
+    public MemberRegisterResponse(String code, String msg, MemberIdResponse data) {
         this.code = code;
         this.msg = msg;
         this.data = data;

--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -30,20 +30,27 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberRegisterResponse register(MemberRegisterRequest request) {
         try {
-            Optional<Member> member = memberRepository.findByEmail(request.getEmail());
-            if (member.isPresent()) {
+            Optional<Member> memberByEmail = memberRepository.findByEmail(request.getEmail());
+            Optional<Member> memberByNickname = memberRepository.findByNickname(request.getNickname());
+            if (memberByEmail.isPresent()) {
                 return MemberRegisterResponse.builder()
                         .code(HttpStatus.BAD_REQUEST.toString())
                         .msg("이미 가입된 이메일입니다.")
                         .data(null)
                         .build();
             }
+            if (memberByNickname.isPresent()) {
+                return MemberRegisterResponse.builder()
+                        .code(HttpStatus.BAD_REQUEST.toString())
+                        .msg("이미 사용중인 닉네임입니다.")
+                        .data(null)
+                        .build();
+            }
             Member saveMember = request.toEntity();
             saveMember.changePassword(passwordEncoder.encode(saveMember.getPassword()));
             Long saveMemberId = memberRepository.save(saveMember).getMemberId();
-            MemberIdWithPointResponse response = MemberIdWithPointResponse.builder()
+            MemberIdResponse response = MemberIdResponse.builder()
                     .memberId(saveMemberId)
-                    .point(saveMember.getPoint().getPoint())
                     .build();
             return MemberRegisterResponse.builder()
                     .code(HttpStatus.OK.toString())

--- a/src/test/java/com/developers/member/member/controller/RegisterControllerTest.java
+++ b/src/test/java/com/developers/member/member/controller/RegisterControllerTest.java
@@ -55,9 +55,8 @@ public class RegisterControllerTest {
                 .position("백엔드,데브옵스")
                 .skills("Java,Spring")
                 .build();
-        MemberIdWithPointResponse data = MemberIdWithPointResponse.builder()
+        MemberIdResponse data = MemberIdResponse.builder()
                 .memberId(1L)
-                .point(100L)
                 .build();
         MemberRegisterResponse response = MemberRegisterResponse.builder()
                 .code(HttpStatus.OK.toString())

--- a/src/test/java/com/developers/member/member/service/MemberServiceTest.java
+++ b/src/test/java/com/developers/member/member/service/MemberServiceTest.java
@@ -60,9 +60,8 @@ public class MemberServiceTest {
         // then
         assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
         assertThat(response.getMsg()).isEqualTo("회원가입이 정상적으로 처리되었습니다.");
-        assertThat(response.getData()).isInstanceOf(MemberIdWithPointResponse.class);
+        assertThat(response.getData()).isInstanceOf(MemberIdResponse.class);
         assertThat(response.getData().getMemberId()).isEqualTo(member.getMemberId());
-        assertThat(response.getData().getPoint()).isEqualTo(100L);
     }
 
     @DisplayName("작성자 닉네임 정보 조회")


### PR DESCRIPTION
## 🤔 Motivation
- 회원가입 중복 예외 처리 설정

<br>

## 💡 Key Changes
- 사용자가 먼저 선점된 이메일 및 닉네임으로 가입을 시도하면 관련된 에러와 응답을 줘야 하나, 공통적으로 500 code 응답을 주는 상황이 있어 중복 이메일과 중복 닉네임의 예외를 응답으로 주도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
