### PR TITLE
[Fix] 인증 없이 허가해야할 API 목록 명세 추가

### DIFF
--- a/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
+++ b/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
@@ -73,7 +73,14 @@ public class TokenCheckFilter extends OncePerRequestFilter {
          * 문제풀이: 전체 문제 목록 조회
          * 멘토링: 전체 방 목록 조회
          */
-        if (path.startsWith("/api/auth/register")) {
+        if (path.startsWith("/api/auth/register")
+                || path.startsWith("/api/room")
+                || path.startsWith("/api/room/next")
+                || path.startsWith("/api/room/top")
+                || path.startsWith("/api/room/{searchingword}")
+                || path.startsWith("/api/problem")
+                || path.startsWith("/api/problem/list")
+                || path.startsWith("/api/problem/{problemId}/{member}")) {
             log.info("[TokenCheckFilter] Skip Token Check Filter");
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION
## 🤔 Motivation
- 인증 없이 허가해야할 API 목록 명세 추가

<br>

## 💡 Key Changes
- 사용자 서비스에서 사용자 인증 권한을 담당하기에 문제풀이, 멘토링 서비스에서의 요청 API에 대한 인증 여부도 확인을 해주어야 합니다.
- 이를 위해 인증이 필요없이 요청되어야할 API 목록을 확인하고 해당 API들은 TokenCheckFilter가 적용되지 않도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team @soojik @paduck-96 @ITfervor @EagerProgrammer 
