### PR TITLE
[Fix] 토큰 재발급 API 요청 허가 설정 추가

### DIFF
--- a/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
+++ b/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
@@ -80,7 +80,8 @@ public class TokenCheckFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/room/{searchingword}")
                 || path.startsWith("/api/problem")
                 || path.startsWith("/api/problem/list")
-                || path.startsWith("/api/problem/{problemId}/{member}")) {
+                || path.startsWith("/api/problem/{problemId}/{member}")
+                || path.startsWith("/api/auth/member")) {
             log.info("[TokenCheckFilter] Skip Token Check Filter");
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
+++ b/src/main/java/com/developers/member/auth/security/filter/TokenCheckFilter.java
@@ -81,7 +81,7 @@ public class TokenCheckFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/problem")
                 || path.startsWith("/api/problem/list")
                 || path.startsWith("/api/problem/{problemId}/{member}")
-                || path.startsWith("/api/auth/member")) {
+                || path.startsWith("/api/auth/refresh")) {
             log.info("[TokenCheckFilter] Skip Token Check Filter");
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION
## 🤔 Motivation
- 토큰 재발급 API 요청 허가 설정 추가

<br>

## 💡 Key Changes
- 클라이언트가 가지고 있는 토큰 만료시 사용자 모르게 토큰을 재발급하여 재로그인을 하지 않도록 하기 위해 토큰을 재발급 해줘야 하는데, 재발급 해주는 API는 인증 없이 요청할 수 있도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
