### PR TITLE
[Fix] 사용자 경력정보 관련 API 수정 및 RDS 접속정보 추가

### DIFF
--- a/src/main/java/com/developers/member/career/dto/request/MemberCareerSaveRequest.java
+++ b/src/main/java/com/developers/member/career/dto/request/MemberCareerSaveRequest.java
@@ -11,15 +11,8 @@ import java.util.List;
 @Builder
 @Getter
 public class MemberCareerSaveRequest {
+    private Long memberId;
     private String company;
     private LocalDate careerStart;
     private LocalDate careerEnd;
-
-    public Career toEntity() {
-        return Career.builder()
-                .company(company)
-                .start(careerStart)
-                .end(careerEnd)
-                .build();
-    }
 }

--- a/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
+++ b/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
@@ -69,16 +69,30 @@ public class CareerServiceImpl implements CareerService {
     @Override
     public MemberCareerResponse saveCareer(MemberCareerSaveRequest request) {
         try {
-            Career career = request.toEntity();
-            careerRepository.save(career);
-            CareerIdResponse careerId = CareerIdResponse.builder()
-                    .careerId(career.getCareerId())
-                    .build();
-            return MemberCareerResponse.builder()
-                    .code(HttpStatus.OK.toString())
-                    .msg("정상적으로 경력정보가 등록되었습니다.")
-                    .data(careerId)
-                    .build();
+            Optional<Member> member = memberRepository.findById(request.getMemberId());
+            if(member.isPresent()) {
+                Career career = Career.builder()
+                        .member(member.get())
+                        .company(request.getCompany())
+                        .start(request.getCareerStart())
+                        .end(request.getCareerEnd())
+                        .build();
+                careerRepository.save(career);
+                CareerIdResponse careerId = CareerIdResponse.builder()
+                        .careerId(career.getCareerId())
+                        .build();
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.OK.toString())
+                        .msg("정상적으로 경력정보가 등록되었습니다.")
+                        .data(careerId)
+                        .build();
+            } else {
+                return MemberCareerResponse.builder()
+                        .code(HttpStatus.NOT_FOUND.toString())
+                        .msg("존재하지 않는 사용자입니다.")
+                        .data(null)
+                        .build();
+            }
         } catch (Exception e) {
             return MemberCareerResponse.builder()
                     .code(HttpStatus.INTERNAL_SERVER_ERROR.toString())

--- a/src/main/java/com/developers/member/config/SecurityConfig.java
+++ b/src/main/java/com/developers/member/config/SecurityConfig.java
@@ -108,16 +108,12 @@ public class SecurityConfig {
 
         // APILoginFilter의 위치 조정, 로그인 필터 적용
         http.addFilterBefore(apiLoginFilter, UsernamePasswordAuthenticationFilter.class);
-
         // Acess 토큰 검증 필터 적용하기
         http.addFilterBefore(tokenCheckFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
-
         // Refresh 토큰 컴증 필터를 적용하기
         http.addFilterBefore(new RefreshTokenFilter("/api/auth/refresh", jwtUtil), TokenCheckFilter.class);
-
         // API Server는 세션을 사용하지 않기에 세션 사용 중지
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-
         // API Server에서 동작헤야 하기 때문에 CORS 설정 추가
         http.cors(httpSecurityCorsConfigurer -> {
             httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource());

--- a/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
+++ b/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -145,9 +146,9 @@ public class CareerRepositoryTest {
         memberRepository.save(member);
         Career saveCareer = careerRepository.save(career);
         careerRepository.deleteById(saveCareer.getCareerId());
-        List<Career> result = careerRepository.findAll();
+        Optional<Career> result = careerRepository.findById(saveCareer.getCareerId());
 
         // then
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/developers/member/career/service/CareerServiceTest.java
+++ b/src/test/java/com/developers/member/career/service/CareerServiceTest.java
@@ -45,12 +45,28 @@ public class CareerServiceTest {
     public void saveCareer() {
         LocalDate curruntDate = LocalDate.now();
         // given
+        Member member = Member.builder()
+                .email("test001@kakao.com")
+                .password("kakao123")
+                .nickname("test001")
+                .type(Type.LOCAL)
+                .role(Role.USER)
+                .isMentor(false)
+                .point(100L)
+                .build();
         MemberCareerSaveRequest request = MemberCareerSaveRequest.builder()
+                .memberId(member.getMemberId())
                 .company("마이다스 아이티")
                 .careerStart(curruntDate)
                 .careerEnd(curruntDate)
                 .build();
-        Career career = request.toEntity();
+        Career career = Career.builder()
+                .member(member)
+                .company(request.getCompany())
+                .start(request.getCareerStart())
+                .end(request.getCareerEnd())
+                .build();
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
         when(careerRepository.save(any())).thenReturn(career);
 
         // when

--- a/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
+++ b/src/test/java/com/developers/member/point/repository/PointRepositoryTest.java
@@ -38,7 +38,7 @@ public class PointRepositoryTest {
     public void increasePoint() {
         // given
         Member member = Member.builder()
-                .email("lango@kakao.com")
+                .email("testpointincrease001@kakao.com")
                 .password("kakao123")
                 .nickname("lango")
                 .type(Type.LOCAL)
@@ -50,6 +50,7 @@ public class PointRepositoryTest {
                 .build();
         memberRepository.save(member);
         Optional<Member> saveMember = memberRepository.findById(member.getMemberId());
+        System.out.println(saveMember.get().getMemberId());
         Point point = saveMember.get().getPoint();
         point.increase(10L);
         pointRepository.save(point);
@@ -66,7 +67,7 @@ public class PointRepositoryTest {
     public void decreasePoint() {
         // given
         Member member = Member.builder()
-                .email("lango@kakao.com")
+                .email("testpointdecrease001@kakao.com")
                 .password("kakao123")
                 .nickname("lango")
                 .type(Type.LOCAL)


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 경력정보 관련 API 수정 및 RDS 접속정보 추가

<br>

## 💡 Key Changes
- 사용자 경력정보 등록 API에 `memberId`가 누락되어 있어서 `memberId`를 요청 객체에 담아오도록 수정했습니다.
- 테스트 DB로 컨테이너에 임시로 띄워둔 DB를 사용하고 있었는데 운영환경 구축을 위해 RDS로 연결할 수 있도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
