### PR TITLE
[Fix] 사용자 경력정보 조회시 경력번호 응답 누락 수정

### DIFF
--- a/src/main/java/com/developers/member/career/dto/response/MemberOfCareer.java
+++ b/src/main/java/com/developers/member/career/dto/response/MemberOfCareer.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 @Builder
 @Getter
 public class MemberOfCareer {
+    private Long careerId;
     private String company;
     private LocalDate careerStart;
     private LocalDate careerEnd;

--- a/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
+++ b/src/main/java/com/developers/member/career/service/CareerServiceImpl.java
@@ -33,6 +33,7 @@ public class CareerServiceImpl implements CareerService {
                 List<MemberOfCareer> careerList = new ArrayList<>();
                 for(Career career : careers) {
                     MemberOfCareer m = MemberOfCareer.builder()
+                            .careerId(career.getCareerId())
                             .company(career.getCompany())
                             .careerStart(career.getStart())
                             .careerEnd(career.getEnd())


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 경력정보 조회시 경력번호 응답 누락 수정

<br>

## 💡 Key Changes
- 마이페이지에 접근하여 사용자의 경력정보를 조회할 때 N개의 경력정보의 PK 값을 응답으로 주어야 하나 누락되어 주지않고 있음을 확인하였고, `careerId`를 응답으로 줄 수 있도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
