### PR TITLE
[Fix] 회원가입시 중복 여부를 확인하기 위한 로그 추가

### DIFF
--- a/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/developers/member/member/service/MemberServiceImpl.java
@@ -33,6 +33,7 @@ public class MemberServiceImpl implements MemberService {
             Optional<Member> memberByEmail = memberRepository.findByEmail(request.getEmail());
             Optional<Member> memberByNickname = memberRepository.findByNickname(request.getNickname());
             if (memberByEmail.isPresent()) {
+                log.info("[MemberServiceImpl] Member Email Already Exist ..");
                 return MemberRegisterResponse.builder()
                         .code(HttpStatus.BAD_REQUEST.toString())
                         .msg("이미 가입된 이메일입니다.")
@@ -40,12 +41,14 @@ public class MemberServiceImpl implements MemberService {
                         .build();
             }
             if (memberByNickname.isPresent()) {
+                log.info("[MemberServiceImpl] Member Nickname Already Exist ..");
                 return MemberRegisterResponse.builder()
                         .code(HttpStatus.BAD_REQUEST.toString())
                         .msg("이미 사용중인 닉네임입니다.")
                         .data(null)
                         .build();
             }
+            log.info("[MemberServiceImpl] Member Email with Nickname Available !");
             Member saveMember = request.toEntity();
             saveMember.changePassword(passwordEncoder.encode(saveMember.getPassword()));
             Long saveMemberId = memberRepository.save(saveMember).getMemberId();


### PR DESCRIPTION
## 🤔 Motivation
- 회원가입시 중복 여부를 확인하기 위한 로그 추가

<br>

## 💡 Key Changes
- 사용자 회원가입시 중복 회원가입을 방지하기 위해 서버 로그를 살펴보아야 합니다. 이를 위해 회원가입 로직에서 이메일, 닉네임 중복 여부를 확인할 수 있도록 로그를 추가하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
