### PR TITLE
[Fix] 사용자 로그인 실패 핸들러 설정 변경

### DIFF
--- a/src/main/java/com/developers/member/config/SecurityConfig.java
+++ b/src/main/java/com/developers/member/config/SecurityConfig.java
@@ -129,16 +129,15 @@ public class SecurityConfig {
                 .formLogin()
                 .loginPage("/login")
                 .successForwardUrl("/")
-                .failureForwardUrl("/")
                 .permitAll()
                 .and()
                 .logout()
                 .logoutUrl("/api/auth/logout")
                 .logoutSuccessUrl("/");
         http
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint());
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+//                .and()
+//                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint());
         return http.build();
     }
 }

--- a/src/test/java/com/developers/member/badge/repository/BadgeRepositoryTest.java
+++ b/src/test/java/com/developers/member/badge/repository/BadgeRepositoryTest.java
@@ -43,9 +43,9 @@ public class BadgeRepositoryTest {
     public void getMyBadge() {
         // given
         Member member = Member.builder()
-                .email("test001@kakao.com")
+                .email("developers-test001@test.com")
                 .password("kakao123")
-                .nickname("test001")
+                .nickname("dvlptest@1")
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .isMentor(false)
@@ -81,9 +81,9 @@ public class BadgeRepositoryTest {
     public void getMyBadgeList() {
         // given
         Member member = Member.builder()
-                .email("test001@kakao.com")
+                .email("test001@test.com")
                 .password("kakao123")
-                .nickname("test001")
+                .nickname("dvlptest@1")
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .isMentor(false)

--- a/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
+++ b/src/test/java/com/developers/member/career/repository/CareerRepositoryTest.java
@@ -42,9 +42,9 @@ public class CareerRepositoryTest {
         // given
         LocalDate currentDate = LocalDate.now();
         Member member = Member.builder()
-                .email("test001@kakao.com")
+                .email("test001@test.com")
                 .password("kakao123")
-                .nickname("test001")
+                .nickname("dvlptest@1")
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .isMentor(false)
@@ -87,9 +87,9 @@ public class CareerRepositoryTest {
         // given
         LocalDate currentDate = LocalDate.now();
         Member member = Member.builder()
-                .email("test002@kakao.com")
+                .email("test002@test.com")
                 .password("kakao123")
-                .nickname("test002")
+                .nickname("dvlptest@1")
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .isMentor(false)
@@ -123,9 +123,9 @@ public class CareerRepositoryTest {
         // given
         LocalDate currentDate = LocalDate.now();
         Member member = Member.builder()
-                .email("test002@kakao.com")
+                .email("test002@test.com")
                 .password("kakao123")
-                .nickname("test002")
+                .nickname("dvlptest@1")
                 .type(Type.LOCAL)
                 .role(Role.USER)
                 .isMentor(false)

--- a/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/developers/member/member/repository/MemberRepositoryTest.java
@@ -216,7 +216,7 @@ public class MemberRepositoryTest {
     public void updateProfileImage() {
         // given
         Member member = Member.builder()
-                .email("test001@kakao.com")
+                .email("test001@test.com")
                 .password("kakao123")
                 .nickname("member@1")
                 .type(Type.LOCAL)
@@ -240,7 +240,7 @@ public class MemberRepositoryTest {
     public void updatePassword() {
         // given
         Member member = Member.builder()
-                .email("test001@kakao.com")
+                .email("test001@test.com")
                 .password("kakao123")
                 .nickname("member@1")
                 .type(Type.LOCAL)


### PR DESCRIPTION
## 🤔 Motivation
- 사용자 로그인 실패 핸들러 설정 변경

<br>

## 💡 Key Changes
- 로그인 실패시 아래 화면과 같이 Spring Security에서 제공하는 로그인 alert을 사용하고 있는 문제를 확인하였고, 서버에서의 Exception Handler 설정을 변경했습니다.

![image](https://user-images.githubusercontent.com/59594946/234330930-7af56314-7c00-4ade-a0a5-6acb64568f6d.png)

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
