### PR TITLE
[Fix] 포인트 랭킹 조회 API 응답 속성 memberId 추가

### DIFF
--- a/src/main/java/com/developers/member/point/dto/response/PointWithNickname.java
+++ b/src/main/java/com/developers/member/point/dto/response/PointWithNickname.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @Getter
 public class PointWithNickname {
     private Long point;
+    private Long memberId;
     private String nickname;
 }

--- a/src/main/java/com/developers/member/point/service/PointServiceImpl.java
+++ b/src/main/java/com/developers/member/point/service/PointServiceImpl.java
@@ -118,6 +118,7 @@ public class PointServiceImpl implements PointService {
             for (Point point : pointRankingList) {
                 PointWithNickname resPoint = PointWithNickname.builder()
                         .point(point.getPoint())
+                        .memberId(point.getMember().getMemberId())
                         .nickname(point.getMember().getNickname())
                         .build();
                 result.add(resPoint);


### PR DESCRIPTION
## 🤔 Motivation
- 포인트 랭킹 조회 API 응답 속성 memberId 추가

<br>

## 💡 Key Changes
- 포인트 TOP 10 랭킹 조회 기능에 사용자 이력 페이지 추가를 위해 포인트 랭킹 조회 API 응답 속성에 `memberId`를 추가했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
